### PR TITLE
change: the bot will now support channel comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
+#virtual enviroment
+.venv
+
+#vscode
+.vscode
+
 config/adminsid.json
 config/token.conf
 data/spot.db
 data/banned.lst
+data/*/*.json
 *pyc

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If you want to test the bot by creating your personal istance, follow this steps
 
 #### How to use
 Add the API TOKEN in /config/token.conf
+Add the numeric ids of the requested chats in /config/adminsid.json
 Run from shell:
 ```
 $ python main.py

--- a/config/adminsid.json.dist
+++ b/config/adminsid.json.dist
@@ -1,4 +1,5 @@
 {
 	"admins_chat_id" : "xxxxxxxx",
-	"channel_chat_id" : "@yyyyyyyyyyy"	
+	"comments_chat_id" : "zzzzzzzz",
+	"channel_chat_id" : "yyyyyyyyyyy"	
 }

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ def main():
     dp.add_handler(CommandHandler('rules', rules_cmd))
     dp.add_handler(CommandHandler('ban', ban_cmd, pass_args = True))
     dp.add_handler(MessageHandler(Filters.reply , message_handle))
+    dp.add_handler(MessageHandler(Filters.forwarded, comment_msg))
     dp.add_handler(CallbackQueryHandler(callback_spot))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-python-telegram-bot
-
+python-telegram-bot==12.8


### PR DESCRIPTION
As soon as spot is published in the channel, the bot will make a comment under it, allowing the users to vote the post
Also, there are popups when a vote is cast

The annoying thing is that the adminsid.json file now needs 3 numeric ids for the admin group, the channel and the group that hosts the channel's comments