### PR TITLE
Added a simple /stats command, scheduled clean_pending, minor refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Telegram-SpottedDMI-Bot
 
-**Telegram-SpottedDMI-Bot** [**@Spotted_DMI_Bot**](https://telegram.me/Spotted_DMI_Bot) is a Telegram bot
+**Telegram-SpottedDMI-Bot** is the platform that powers **[@Spotted_DMI_Bot](https://telegram.me/Spotted_DMI_Bot)**, a Telegram bot that let students send an anonymous message to the channel community.
 
 ### Using the live version
 The bot is live on Telegram with the username [**@Spotted_DMI_Bot**](https://telegram.me/Spotted_DMI_Bot).
 To see the posts, once published, check [**Spotted DMI**](https://t.me/Spotted_DMI)
 Send **'/start'** to start it, **'/help'** to see a list of commands.
+
 Please note that the commands and their answers are in Italian.
 
 ## Table of contents

--- a/data/markdown/help.md
+++ b/data/markdown/help.md
@@ -4,4 +4,6 @@
 
 /rules: Mostra l'elenco di regole da rispettare nell'invio degli spot\.
 
+/stats: Visualizza alcune statistiche interessanti sugli spot pubblicati\.
+
 /settings: Decidi se vuoi pubblicare in forma anonima o vuoi che il post faccia riferimento a te\. Di default è anonimo

--- a/main.py
+++ b/main.py
@@ -35,10 +35,10 @@ def add_commands(up: Updater):
 
 
 def add_handlers(dp: Dispatcher):
-    """Adds all the needed handlers to the dipatcher
+    """Adds all the needed handlers to the dispatcher
 
     Args:
-        dp (Dispatcher): supplyed dispacther
+        dp (Dispatcher): supplyed dispatcher
     """
     if config_map['debug']['local_log']:  # add MessageHandler only if log_message is enabled
         dp.add_handler(MessageHandler(Filters.all, log_message), 1)

--- a/main.py
+++ b/main.py
@@ -12,8 +12,8 @@ from modules.debug.log_manager import log_message
 from modules.data.data_reader import config_map
 # commands
 from modules.handlers.command_handlers import STATE, start_cmd, help_cmd, settings_cmd, post_cmd, ban_cmd, reply_cmd,\
-    clean_pending_cmd, post_msg, rules_cmd, sban_cmd, cancel_cmd, forwarded_post_msg
-from modules.handlers.callback_handlers import meme_callback
+    clean_pending_cmd, post_msg, rules_cmd, sban_cmd, cancel_cmd, stats_cmd, forwarded_post_msg
+from modules.handlers.callback_handlers import meme_callback, stats_callback
 # endregion
 
 
@@ -28,6 +28,7 @@ def add_commands(up: Updater):
         BotCommand("spot", "inizia a spottare"),
         BotCommand("help ", "funzionamento e scopo del bot"),
         BotCommand("rules ", "regole da tenere a mente"),
+        BotCommand("stats", "visualizza statistiche sugli spot"),
         BotCommand("settings", "cambia le impostazioni di privacy")
     ]
     up.bot.set_my_commands(commands=commands)
@@ -46,6 +47,7 @@ def add_handlers(dp: Dispatcher):
     dp.add_handler(CommandHandler("start", start_cmd))
     dp.add_handler(CommandHandler("help", help_cmd))
     dp.add_handler(CommandHandler("rules", rules_cmd))
+    dp.add_handler(CommandHandler("stats", stats_cmd))
     dp.add_handler(CommandHandler("settings", settings_cmd))
     dp.add_handler(CommandHandler("sban", sban_cmd))
     dp.add_handler(CommandHandler("clean_pending", clean_pending_cmd))
@@ -67,6 +69,7 @@ def add_handlers(dp: Dispatcher):
 
     # Callback handlers
     dp.add_handler(CallbackQueryHandler(meme_callback, pattern=r"^meme_\.*"))
+    dp.add_handler(CallbackQueryHandler(stats_callback, pattern=r"^stats_\.*"))
 
     if config_map['meme']['comments']:
         dp.add_handler(MessageHandler(Filters.forwarded, forwarded_post_msg))

--- a/main.py
+++ b/main.py
@@ -2,6 +2,8 @@
 # region imports
 # libs
 import warnings
+from datetime import time
+from pytz import utc
 # telegram
 from telegram import BotCommand
 from telegram.ext import Updater, CommandHandler, MessageHandler, CallbackQueryHandler, ConversationHandler,\
@@ -10,10 +12,11 @@ from telegram.ext import Updater, CommandHandler, MessageHandler, CallbackQueryH
 from modules.debug.log_manager import log_message
 # data
 from modules.data.data_reader import config_map
-# commands
+# handlers
 from modules.handlers.command_handlers import STATE, start_cmd, help_cmd, settings_cmd, post_cmd, ban_cmd, reply_cmd,\
     clean_pending_cmd, post_msg, rules_cmd, sban_cmd, cancel_cmd, stats_cmd, forwarded_post_msg
 from modules.handlers.callback_handlers import meme_callback, stats_callback
+from modules.handlers.job_handlers import clean_pending_job
 # endregion
 
 
@@ -75,12 +78,22 @@ def add_handlers(dp: Dispatcher):
         dp.add_handler(MessageHandler(Filters.forwarded, forwarded_post_msg))
 
 
+def add_jobs(dp: Dispatcher):
+    """Adds all the jobs to be scheduled to the dispatcher
+
+    Args:
+        dp (Dispatcher): supplyed dispatcher
+    """
+    dp.job_queue.run_daily(clean_pending_job, time=time(hour=5, tzinfo=utc))  # run each day at 05:00 utc
+
+
 def main():
     """Main function
     """
     updater = Updater(config_map['token'], request_kwargs={'read_timeout': 20, 'connect_timeout': 20}, use_context=True)
     add_commands(updater)
     add_handlers(updater.dispatcher)
+    add_jobs(updater.dispatcher)
 
     updater.start_polling()
     updater.idle()

--- a/modules/data/meme_data.py
+++ b/modules/data/meme_data.py
@@ -1,4 +1,4 @@
-"""Data management for the meme bot"""
+"""Data management for the bot"""
 from typing import Optional, Tuple
 from datetime import datetime
 from telegram import Message

--- a/modules/handlers/callback_handlers.py
+++ b/modules/handlers/callback_handlers.py
@@ -26,12 +26,10 @@ def meme_callback(update: Update, context: CallbackContext) -> int:
     info = get_callback_info(update, context)
     data = info['data']
     try:
-        message_text, reply_markup, output = globals()[f'{data[5:]}_callback'](update,
-                                                                               context)  # call the function based on its name
-    except KeyError:
+        message_text, reply_markup, output = globals()[f'{data[5:]}_callback'](info)  # call the function based on its name
+    except KeyError as e:
         message_text = reply_markup = output = None
-        print("[error] (meme) meme_callback: the function corrisponding to this callback_data was not found")
-        print(f"callback_data: {data}, Argument passed: {data[5:]}_callback")
+        logger.error("meme_callback: %s", e)
 
     if message_text:  # if there is a valid text, edit the menu with the new text
         info['bot'].edit_message_text(chat_id=info['chat_id'],
@@ -46,19 +44,17 @@ def meme_callback(update: Update, context: CallbackContext) -> int:
 
 
 # region handle meme_callback
-def confirm_yes_callback(update: Update, context: CallbackContext) -> Tuple[str, InlineKeyboardMarkup, int]:
+def confirm_yes_callback(info: dict) -> Tuple[str, InlineKeyboardMarkup, int]:
     """Handles the confirm_yes callback.
     Saves the post as pending and sends it to the admins for them to check
 
     Args:
-        update (Update): update event
-        context (CallbackContext): context passed by the handler
+        info (dict): information about the callback
 
     Returns:
         Tuple[str, InlineKeyboardMarkup, int]: text and replyMarkup that make up the reply, new conversation state
     """
-    info = get_callback_info(update, context)
-    user_message = update.callback_query.message.reply_to_message
+    user_message = info['message'].reply_to_message
     admin_message = send_post_to(message=user_message, bot=info['bot'], destination="admin")
     if admin_message:
         text = "Il tuo post è in fase di valutazione\n"\
@@ -68,13 +64,12 @@ def confirm_yes_callback(update: Update, context: CallbackContext) -> Tuple[str,
     return text, None, STATE['end']
 
 
-def confirm_no_callback(update: Update, context: CallbackContext) -> Tuple[str, InlineKeyboardMarkup, int]:
+def confirm_no_callback(info: dict) -> Tuple[str, InlineKeyboardMarkup, int]:  # pylint: disable=unused-argument
     """Handles the confirm_no callback.
     Saves the post as pending and sends it to the admins for them to check
 
     Args:
-        update (Update): update event
-        context (CallbackContext): context passed by the handler
+        info (dict): information about the callback
 
     Returns:
         Tuple[str, InlineKeyboardMarkup, int]: text and replyMarkup that make up the reply, new conversation state
@@ -83,20 +78,18 @@ def confirm_no_callback(update: Update, context: CallbackContext) -> Tuple[str, 
     return message_text, None, STATE['end']
 
 
-def settings_anonimo_callback(update: Update, context: CallbackContext) -> Tuple[str, InlineKeyboardMarkup, int]:
+def settings_anonimo_callback(info: dict) -> Tuple[str, InlineKeyboardMarkup, int]:
     """Handles the settings_sei_ghei callback.
     Removes the user_id from the table of credited users, if present
 
     Args:
-        update (Update): update event
-        context (CallbackContext): context passed by the handler
+        info (dict): information about the callback
 
     Returns:
         Tuple[str, InlineKeyboardMarkup, int]: text and replyMarkup that make up the reply, new conversation state
     """
-    user_id = update.callback_query.from_user.id
     # if the user was already anonym
-    if MemeData.become_anonym(user_id=user_id):
+    if MemeData.become_anonym(user_id=info['sender_id']):
         text = "Sei già anonimo"
     else:
         text = "La tua preferenza è stata aggiornata\n"\
@@ -105,57 +98,51 @@ def settings_anonimo_callback(update: Update, context: CallbackContext) -> Tuple
     return text, None, None
 
 
-def settings_credit_callback(update: Update, context: CallbackContext) -> Tuple[str, InlineKeyboardMarkup, int]:
+def settings_credit_callback(info: dict) -> Tuple[str, InlineKeyboardMarkup, int]:
     """Handles the settings_foto_cane callback.
     Adds the user_id to the table of credited users, if it wasn't already there
 
     Args:
-        update (Update): update event
-        context (CallbackContext): context passed by the handler
+        info (dict): information about the callback
 
     Returns:
         Tuple[str, InlineKeyboardMarkup, int]: text and replyMarkup that make up the reply, new conversation state
     """
-    username = update.callback_query.from_user.username
-    user_id = update.callback_query.from_user.id
-
     # if the user was already credited
-    if MemeData.become_credited(user_id=user_id):
+    if MemeData.become_credited(user_id=info['sender_id']):
         text = "Sei già creditato nei post\n"
     else:
         text = "La tua preferenza è stata aggiornata\n"
 
-    if username:  # the user has a valid username
-        text += f"I tuoi post avranno come credit @{username}"
+    if info['sender_username']:  # the user has a valid username
+        text += f"I tuoi post avranno come credit @{info['sender_username']}"
     else:
         text += "ATTENZIONE:\nNon hai nessun username associato al tuo account telegram\n"\
             "Se non lo aggiungi, non sarai creditato"
     return text, None, None
 
 
-def approve_yes_callback(update: Update, context: CallbackContext) -> Tuple[str, InlineKeyboardMarkup, int]:
+def approve_yes_callback(info: dict) -> Tuple[str, InlineKeyboardMarkup, int]:
     """Handles the approve_yes callback.
     Approves the post, deleting it from the pending_post table, publishing it in the channel \
     and putting it in the published post table
 
     Args:
-        update (Update): update event
-        context (CallbackContext): context passed by the handler
+        info (dict): information about the callback
 
     Returns:
         Tuple[str, InlineKeyboardMarkup, int]: text and replyMarkup that make up the reply, new conversation state
     """
-    info = get_callback_info(update, context)
     n_approve = MemeData.set_admin_vote(info['sender_id'], info['message_id'], info['chat_id'], True)
 
     # The post passed the approval phase and is to be published
     if n_approve >= config_map['meme']['n_votes']:
-        message = update.callback_query.message
+        message = info['message']
         user_id = MemeData.get_user_id(g_message_id=info['message_id'], group_id=info['chat_id'])
         published_post = send_post_to(message=message, bot=info['bot'], destination="channel")
 
         if config_map['meme']['comments']:  # if comments are enabled, save the user_id, so the user can be credited
-            context.bot_data[f"{published_post.chat_id},{published_post.message_id}"] = user_id
+            info['bot_data'][f"{published_post.chat_id},{published_post.message_id}"] = user_id
 
         try:
             info['bot'].send_message(chat_id=user_id,
@@ -169,24 +156,22 @@ def approve_yes_callback(update: Update, context: CallbackContext) -> Tuple[str,
         return None, None, None
 
     if n_approve != -1:  # the vote changed
-        keyboard = update.callback_query.message.reply_markup.inline_keyboard
+        keyboard = info['reply_markup'].inline_keyboard
         return None, update_approve_kb(keyboard, info['message_id'], info['chat_id'], approve=n_approve), None
 
     return None, None, None
 
 
-def approve_no_callback(update: Update, context: CallbackContext) -> Tuple[str, InlineKeyboardMarkup, int]:
+def approve_no_callback(info: dict) -> Tuple[str, InlineKeyboardMarkup, int]:
     """Handles the approve_no callback.
     Rejects the post, deleting it from the pending_post table
 
     Args:
-        update (Update): update event
-        context (CallbackContext): context passed by the handler
+        info (dict): information about the callback
 
     Returns:
         Tuple[str, InlineKeyboardMarkup, int]: text and replyMarkup that make up the reply, new conversation state
     """
-    info = get_callback_info(update, context)
     n_reject = MemeData.set_admin_vote(info['sender_id'], info['message_id'], info['chat_id'], False)
 
     # The post has been refused
@@ -206,24 +191,22 @@ def approve_no_callback(update: Update, context: CallbackContext) -> Tuple[str, 
         return None, None, None
 
     if n_reject != -1:  # the vote changed
-        keyboard = update.callback_query.message.reply_markup.inline_keyboard
+        keyboard = info['reply_markup'].inline_keyboard
         return None, update_approve_kb(keyboard, info['message_id'], info['chat_id'], reject=n_reject), None
 
     return None, None, None
 
 
-def vote_yes_callback(update: Update, context: CallbackContext) -> Tuple[str, InlineKeyboardMarkup, int]:
+def vote_yes_callback(info: dict) -> Tuple[str, InlineKeyboardMarkup, int]:
     """Handles the vote_yes callback.
     Upvotes the post
 
     Args:
-        update (Update): update event
-        context (CallbackContext): context passed by the handler
+        info (dict): information about the callback
 
     Returns:
         Tuple[str, InlineKeyboardMarkup, int]: text and replyMarkup that make up the reply, new conversation state
     """
-    info = get_callback_info(update, context)
     n_upvotes, was_added = MemeData.set_user_vote(user_id=info['sender_id'],
                                                   c_message_id=info['message_id'],
                                                   channel_id=info['chat_id'],
@@ -234,24 +217,22 @@ def vote_yes_callback(update: Update, context: CallbackContext) -> Tuple[str, In
             info['bot'].answerCallbackQuery(callback_query_id=info['query_id'], text="Hai messo un 👍")
         else:
             info['bot'].answerCallbackQuery(callback_query_id=info['query_id'], text="Hai tolto il 👍")
-        keyboard = update.callback_query.message.reply_markup.inline_keyboard
+        keyboard = info['reply_markup'].inline_keyboard
         return None, update_vote_kb(keyboard, info['message_id'], info['chat_id'], upvote=n_upvotes), None
 
     return None, None, None
 
 
-def vote_no_callback(update: Update, context: CallbackContext) -> Tuple[str, InlineKeyboardMarkup, int]:
+def vote_no_callback(info: dict) -> Tuple[str, InlineKeyboardMarkup, int]:
     """Handles the vote_no callback.
     Downvotes the post
 
     Args:
-        update (Update): update event
-        context (CallbackContext): context passed by the handler
+        info (dict): information about the callback
 
     Returns:
         Tuple[str, InlineKeyboardMarkup, int]: text and replyMarkup that make up the reply, new conversation state
     """
-    info = get_callback_info(update, context)
     n_downvotes, was_added = MemeData.set_user_vote(user_id=info['sender_id'],
                                                     c_message_id=info['message_id'],
                                                     channel_id=info['chat_id'],
@@ -262,7 +243,7 @@ def vote_no_callback(update: Update, context: CallbackContext) -> Tuple[str, Inl
             info['bot'].answerCallbackQuery(callback_query_id=info['query_id'], text="Hai messo un 👎")
         else:
             info['bot'].answerCallbackQuery(callback_query_id=info['query_id'], text="Hai tolto il 👎")
-        keyboard = update.callback_query.message.reply_markup.inline_keyboard
+        keyboard = keyboard = info['reply_markup'].inline_keyboard
         return None, update_vote_kb(keyboard, info['message_id'], info['chat_id'], downvote=n_downvotes), None
 
     return None, None, None

--- a/modules/handlers/callback_handlers.py
+++ b/modules/handlers/callback_handlers.py
@@ -1,4 +1,4 @@
-"""Commands for the meme bot"""
+"""Handles the execution of callbacks by the bot"""
 from typing import Tuple
 from telegram import Update, InlineKeyboardMarkup
 from telegram.ext import CallbackContext

--- a/modules/handlers/command_handlers.py
+++ b/modules/handlers/command_handlers.py
@@ -1,4 +1,4 @@
-"""Commands for the meme bot"""
+"""Handles the execution of commands by the bot"""
 from datetime import datetime, timedelta, timezone
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, ParseMode
 from telegram.ext import CallbackContext

--- a/modules/handlers/command_handlers.py
+++ b/modules/handlers/command_handlers.py
@@ -8,7 +8,7 @@ from modules.data.data_reader import read_md, config_map
 from modules.data.meme_data import MemeData
 from modules.utils.info_util import get_message_info, check_message_type
 from modules.utils.post_util import send_post_to
-from modules.utils.keyboard_util import get_confirm_kb
+from modules.utils.keyboard_util import get_confirm_kb, get_stats_kb
 
 STATE = {'posting': 1, 'confirm': 2, 'end': -1}
 
@@ -249,6 +249,19 @@ def cancel_cmd(update: Update, context: CallbackContext) -> int:
 
     info['bot'].send_message(chat_id=info['chat_id'], text="Post annullato")
     return STATE['end']
+
+
+def stats_cmd(update: Update, context: CallbackContext):
+    """Handles the /stats command.
+    Lets the user choose what stats they want to see
+
+    Args:
+        update (Update): update event
+        context (CallbackContext): context passed by the handler
+    """
+    info = get_message_info(update, context)
+
+    info['bot'].send_message(chat_id=info['chat_id'], text="Che statistica ti interessa?", reply_markup=get_stats_kb())
 
 
 # endregion

--- a/modules/handlers/job_handlers.py
+++ b/modules/handlers/job_handlers.py
@@ -1,0 +1,42 @@
+"""Scheduled jobs of the bot"""
+from datetime import datetime, timezone, timedelta
+from telegram.ext import CallbackContext
+from telegram.error import BadRequest, Unauthorized
+from modules.debug.log_manager import logger
+from modules.data.data_reader import config_map
+from modules.data.meme_data import MemeData
+from modules.utils.info_util import get_job_info
+
+
+def clean_pending_job(context: CallbackContext):
+    """Job called each day at 05:00 utc.
+    Automatically rejects all pending posts that are older than the chosen amount of hours
+
+    Args:
+        context (CallbackContext): context passed by the jobqueue
+    """
+    info = get_job_info(context)
+    admin_group_id = config_map['meme']['group_id']
+
+    before_time = datetime.now(tz=timezone.utc) - timedelta(hours=config_map['meme']['remove_after_h'])
+    pending_meme_ids = MemeData.get_list_pending_memes(group_id=admin_group_id, before=before_time)
+
+    # For each pending meme older than before_time
+    removed = 0
+    for meme_id in pending_meme_ids:
+        try:  # deleting the message associated with the pending meme to remote
+            info['bot'].delete_message(chat_id=admin_group_id, message_id=meme_id)
+            removed += 1
+            try:  # sending a notification to the user
+                user_id = MemeData.get_user_id(group_id=admin_group_id, g_message_id=meme_id)
+                info['bot'].send_message(
+                    chat_id=user_id,
+                    text="Gli admin erano sicuramente molto impegnati e non sono riusciti a valutare lo spot in tempo")
+            except (BadRequest, Unauthorized) as e:
+                logger.warning("Notifying the user on /clean_pending: %s", e)
+        except BadRequest as e:
+            logger.error("Deleting old pending message: %s", e)
+        finally:  # delete the data associated with the pending meme
+            MemeData.remove_pending_meme(group_id=admin_group_id, g_message_id=meme_id)
+
+    info['bot'].send_message(chat_id=admin_group_id, text=f"Sono stati eliminati {removed} messaggi rimasti in sospeso")

--- a/modules/utils/info_util.py
+++ b/modules/utils/info_util.py
@@ -47,6 +47,20 @@ def get_callback_info(update: Update, context: CallbackContext) -> dict:
     }
 
 
+def get_job_info(context: CallbackContext) -> dict:
+    """Get the classic info from the context parameter for jobs
+
+    Args:
+        context (CallbackContext): context passed by the handler
+
+    Returns:
+        dict: {bot}
+    """
+    return {
+        'bot': context.bot,
+    }
+
+
 def check_message_type(message: Message) -> bool:
     """Check that the type of the message is one of the ones supported
 

--- a/modules/utils/info_util.py
+++ b/modules/utils/info_util.py
@@ -11,14 +11,13 @@ def get_message_info(update: Update, context: CallbackContext) -> dict:
         context (CallbackContext): context passed by the handler
 
     Returns:
-        dict: {bot, chat_id, text, message_id, sender_first_name, sender_id}
+        dict: {bot, chat_id, text, message_id, sender_id}
     """
     return {
         'bot': context.bot,
         'chat_id': update.message.chat_id,
         'text': update.message.text,
         'message_id': update.message.message_id,
-        'sender_first_name': update.message.from_user.first_name,
         'sender_id': update.message.from_user.id
     }
 
@@ -31,17 +30,20 @@ def get_callback_info(update: Update, context: CallbackContext) -> dict:
         context (CallbackContext): context passed by the handler
 
     Returns:
-        dict: {bot, chat_id, text, query_id, data, message_id, sender_first_name, sender_id}
+        dict: {bot, bot_data, message, chat_id, text, query_id, data, message_id, sender_id, sender_username, reply_markup}
     """
     return {
         'bot': context.bot,
+        'bot_data': context.bot_data,
+        'message': update.callback_query.message,
         'chat_id': update.callback_query.message.chat_id,
         'text': update.callback_query.message.text,
         'query_id': update.callback_query.id,
         'data': update.callback_query.data,
         'message_id': update.callback_query.message.message_id,
-        'sender_first_name': update.callback_query.from_user.first_name,
-        'sender_id': update.callback_query.from_user.id
+        'sender_id': update.callback_query.from_user.id,
+        'sender_username': update.callback_query.from_user.username,
+        'reply_markup': update.callback_query.message.reply_markup
     }
 
 

--- a/modules/utils/keyboard_util.py
+++ b/modules/utils/keyboard_util.py
@@ -16,6 +16,36 @@ def get_confirm_kb() -> InlineKeyboardMarkup:
     ]])
 
 
+def get_stats_kb() -> InlineKeyboardMarkup:
+    """Generates the InlineKeyboard for the stats menu
+
+    Returns:
+        InlineKeyboardMarkup: new inline keyboard
+    """
+    return InlineKeyboardMarkup([
+        [InlineKeyboardButton("~  Lo spot con più ___  ~", callback_data="none")],
+        [
+            InlineKeyboardButton("voti", callback_data="stats_max,votes"),
+            InlineKeyboardButton("👍", callback_data="stats_max,yes"),
+            InlineKeyboardButton("👎", callback_data="stats_max,no"),
+        ],
+        [InlineKeyboardButton("~  Media di ___ per spot  ~", callback_data="none")],
+        [
+            InlineKeyboardButton("voti", callback_data="stats_avg,votes"),
+            InlineKeyboardButton("👍", callback_data="stats_avg,yes"),
+            InlineKeyboardButton("👎", callback_data="stats_avg,no"),
+        ],
+        [InlineKeyboardButton("~  Numero di ___ totale  ~", callback_data="none")],
+        [
+            InlineKeyboardButton("spot", callback_data="stats_tot,posts"),
+            InlineKeyboardButton("voti", callback_data="stats_tot,votes"),
+            InlineKeyboardButton("👍", callback_data="stats_tot,yes"),
+            InlineKeyboardButton("👎", callback_data="stats_tot,no"),
+        ],
+        [InlineKeyboardButton("Chiudi", callback_data="stats_close,")],
+    ])
+
+
 def get_approve_kb() -> InlineKeyboardMarkup:
     """Generates the InlineKeyboard for the pending post
 

--- a/modules/utils/keyboard_util.py
+++ b/modules/utils/keyboard_util.py
@@ -4,6 +4,18 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from modules.data.meme_data import MemeData
 
 
+def get_confirm_kb() -> InlineKeyboardMarkup:
+    """Generates the InlineKeyboard to confirm the creation of the post
+
+    Returns:
+        InlineKeyboardMarkup: new inline keyboard
+    """
+    return InlineKeyboardMarkup([[
+        InlineKeyboardButton(text="Si", callback_data="meme_confirm_yes"),
+        InlineKeyboardButton(text="No", callback_data="meme_confirm_no")
+    ]])
+
+
 def get_approve_kb() -> InlineKeyboardMarkup:
     """Generates the InlineKeyboard for the pending post
 


### PR DESCRIPTION
A /stats command has been added. It can shows stats about the published posts, like average votes, the spot with most votes and the total number of spot and votes. It **can't** show time related stats, since it would need some timestamp on the spot record, and while it could be done, it wouldn't be compatible with previous spots. [ closes #16 ] 

For the "show the spot with most votes", i tried a "link the message" approach, but I'm not sure it was the right call. If anyone can let his opinion, it would be most helpful.

There is also some minor refactoring, but nothing worth of note, mainly some updates to the comments.