### PR TITLE
/cancel powerup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ meme:
   n_votes: votes needed to approve/reject a pending post
   remove_after_h: number of hours after wich pending posts will be automatically by /clean_pending
   reset_on_load: whether or not the database should reset every time the bot launches. USE CAREFULLY
+  tag: whether or not the bot should tag the admins or just write their usernames
 
 test:
   api_hash: hash of the telegram app used for testing

--- a/config/settings.yaml.dist
+++ b/config/settings.yaml.dist
@@ -8,6 +8,7 @@ meme:
   n_votes: 1
   remove_after_h: 12
   reset_on_load: false
+  tag: false
 test:
   api_hash: ''
   api_id: -1

--- a/data/db/meme_db_init.sql
+++ b/data/db/meme_db_init.sql
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS votes
   user_id BIGINT NOT NULL,
   c_message_id BIGINT NOT NULL,
   channel_id BIGINT NOT NULL,
-  is_upvote boolean NOT NULL,
+  vote varchar(4) NOT NULL,
   PRIMARY KEY (user_id, c_message_id, channel_id),
   FOREIGN KEY (c_message_id, channel_id) REFERENCES published_meme (c_message_id, channel_id) ON DELETE CASCADE ON UPDATE CASCADE
 );

--- a/data/markdown/help.md
+++ b/data/markdown/help.md
@@ -2,6 +2,8 @@
 
 /spot: Pone il bot in ascolto di uno spot\. Rispondi per inviare una richiesta di approvazione al messaggio che vorresti spottare\.
 
+/cancel: Annulla la procedura per la creazione dello spot in corso e cancella l'ultimo spot inviato ancora in valutazione, permettendoti di proporre un nuovo spot immediatamente\.
+
 /rules: Mostra l'elenco di regole da rispettare nell'invio degli spot\.
 
 /stats: Visualizza alcune statistiche interessanti sugli spot pubblicati\.

--- a/main.py
+++ b/main.py
@@ -29,6 +29,8 @@ def add_commands(up: Updater):
     commands = [
         BotCommand("start", "presentazione iniziale del bot"),
         BotCommand("spot", "inizia a spottare"),
+        BotCommand("cancel ",
+                   "annulla la procedura in corso e cancella l'ultimo spot inviato, se non è ancora stato pubblicato"),
         BotCommand("help ", "funzionamento e scopo del bot"),
         BotCommand("rules ", "regole da tenere a mente"),
         BotCommand("stats", "visualizza statistiche sugli spot"),
@@ -46,6 +48,18 @@ def add_handlers(dp: Dispatcher):
     if config_map['debug']['local_log']:  # add MessageHandler only if log_message is enabled
         dp.add_handler(MessageHandler(Filters.all, log_message), 1)
 
+    # Conversation handler
+    dp.add_handler(
+        ConversationHandler(entry_points=[CommandHandler("spot", post_cmd)],
+                            states={
+                                STATE['posting']: [MessageHandler(~Filters.command, post_msg)],
+                                STATE['confirm']: [CallbackQueryHandler(meme_callback, pattern=r"^meme_confirm\.*")]
+                            },
+                            fallbacks=[
+                                CommandHandler("cancel", cancel_cmd),
+                            ],
+                            allow_reentry=False))
+
     # Command handlers
     dp.add_handler(CommandHandler("start", start_cmd))
     dp.add_handler(CommandHandler("help", help_cmd))
@@ -54,24 +68,14 @@ def add_handlers(dp: Dispatcher):
     dp.add_handler(CommandHandler("settings", settings_cmd))
     dp.add_handler(CommandHandler("sban", sban_cmd))
     dp.add_handler(CommandHandler("clean_pending", clean_pending_cmd))
+    dp.add_handler(CommandHandler("cancel", cancel_cmd))  # it must be after the conversation handler's 'cancel'
 
-    # Conversation handler
-    dp.add_handler(
-        ConversationHandler(entry_points=[CommandHandler("spot", post_cmd)],
-                            states={
-                                STATE['posting']: [MessageHandler(~Filters.command, post_msg)],
-                                STATE['confirm']: [CallbackQueryHandler(meme_callback, pattern=r"meme_confirm_\.*")]
-                            },
-                            fallbacks=[
-                                CommandHandler("cancel", cancel_cmd),
-                            ],
-                            allow_reentry=False))
     # MessageHandler
     dp.add_handler(MessageHandler(Filters.reply & Filters.regex(r"^/ban$"), ban_cmd))
     dp.add_handler(MessageHandler(Filters.reply & Filters.regex(r"^/reply"), reply_cmd))
 
     # Callback handlers
-    dp.add_handler(CallbackQueryHandler(meme_callback, pattern=r"^meme_\.*"))
+    dp.add_handler(CallbackQueryHandler(meme_callback, pattern=r"^meme_[^(confirm)]\.*"))
     dp.add_handler(CallbackQueryHandler(stats_callback, pattern=r"^stats_\.*"))
 
     if config_map['meme']['comments']:

--- a/modules/data/meme_data.py
+++ b/modules/data/meme_data.py
@@ -161,6 +161,28 @@ class MemeData():
                               where_args=(g_message_id, group_id))
 
     @staticmethod
+    def cancel_pending_meme(user_id: int) -> tuple:
+        """Removes a post that is still pending if the user so desires
+
+        Args:
+            user_id (int): id of the user that made the post
+
+        Returns:
+            tuple: if a pending post was deleted, returns its id and the admin group id, return None otherwise
+        """
+        result_row = DbManager.select_from(select='g_message_id, group_id',
+                                           table_name='pending_meme',
+                                           where='user_id = %s',
+                                           where_args=(user_id, ))
+
+        if len(result_row) == 0:  # there was no pending meme
+            return None, None
+        else:
+            result_row = result_row[0]
+            MemeData.remove_pending_meme(g_message_id=result_row['g_message_id'], group_id=result_row['group_id'])
+            return result_row['g_message_id'], result_row['group_id']
+
+    @staticmethod
     def insert_published_post(channel_message: Message):
         """Inserts a new post in the table of pending posts
 

--- a/modules/handlers/__init__.py
+++ b/modules/handlers/__init__.py
@@ -1,1 +1,3 @@
 """Modules that handle the events the bot recognizes and reacts to"""
+
+STATE = {'posting': 1, 'confirm': 2, 'end': -1}

--- a/modules/handlers/callback_handlers.py
+++ b/modules/handlers/callback_handlers.py
@@ -11,6 +11,7 @@ from modules.utils.keyboard_util import update_approve_kb, update_vote_kb, get_s
 from modules.utils.post_util import send_post_to, show_admins_votes
 
 STATE = {'posting': 1, 'confirm': 2, 'end': -1}
+REACTION = {'0': "👎", '1': "👍", '2': "🤣", '3': "😡", '4': "🥰"}
 
 
 def meme_callback(update: Update, context: CallbackContext) -> int:
@@ -24,9 +25,9 @@ def meme_callback(update: Update, context: CallbackContext) -> int:
         int: value to return to the handler, if requested
     """
     info = get_callback_info(update, context)
-    data = info['data']
+    data = info['data'].split(",")  # the callback data indicates the correct callback and the arg to pass to it separated by ,
     try:
-        message_text, reply_markup, output = globals()[f'{data[5:]}_callback'](info)  # call the function based on its name
+        message_text, reply_markup, output = globals()[f'{data[0][5:]}_callback'](info, data[1])  # call the correct function
     except KeyError as e:
         message_text = reply_markup = output = None
         logger.error("meme_callback: %s", e)
@@ -44,85 +45,77 @@ def meme_callback(update: Update, context: CallbackContext) -> int:
 
 
 # region handle meme_callback
-def confirm_yes_callback(info: dict) -> Tuple[str, InlineKeyboardMarkup, int]:
-    """Handles the confirm_yes callback.
-    Saves the post as pending and sends it to the admins for them to check
+def confirm_callback(info: dict, arg: str) -> Tuple[str, InlineKeyboardMarkup, int]:
+    """Handles the confirm,[ yes | no ] callback.
+
+    - yes: Saves the post as pending and sends it to the admins for them to check.
+    - no: cancel the current spot conversation
 
     Args:
         info (dict): information about the callback
+        arg (str): [ yes | no ]
 
     Returns:
         Tuple[str, InlineKeyboardMarkup, int]: text and replyMarkup that make up the reply, new conversation state
     """
-    user_message = info['message'].reply_to_message
-    admin_message = send_post_to(message=user_message, bot=info['bot'], destination="admin")
-    if admin_message:
-        text = "Il tuo post è in fase di valutazione\n"\
-            "Una volta pubblicato, lo potrai trovare su @Spotted_DMI"
+    if arg == "yes":  # if the the user wants to publish the post
+        user_message = info['message'].reply_to_message
+        admin_message = send_post_to(message=user_message, bot=info['bot'], destination="admin")
+        if admin_message:
+            text = "Il tuo post è in fase di valutazione\n"\
+                "Una volta pubblicato, lo potrai trovare su @Spotted_DMI"
+        else:
+            text = "Si è verificato un problema\nAssicurati che il tipo di post sia fra quelli consentiti"
+
+    elif arg == "no":  # if the the user changed his mind
+        text = "Va bene, alla prossima 🙃"
+
     else:
-        text = "Si è verificato un problema\nAssicurati che il tipo di post sia fra quelli consentiti"
+        text = None
+        logger.error("confirm_callback: invalid arg '%s'", arg)
+
     return text, None, STATE['end']
 
 
-def confirm_no_callback(info: dict) -> Tuple[str, InlineKeyboardMarkup, int]:  # pylint: disable=unused-argument
-    """Handles the confirm_no callback.
-    Saves the post as pending and sends it to the admins for them to check
+def settings_callback(info: dict, arg: str) -> Tuple[str, InlineKeyboardMarkup, int]:
+    """Handles the settings,[ anonimo | credit ] callback.
+
+    - anonimo: Removes the user_id from the table of credited users, if present.
+    - credit: Adds the user_id to the table of credited users, if it wasn't already there.
 
     Args:
         info (dict): information about the callback
+        arg (str): [ anonimo | credit ]
 
     Returns:
         Tuple[str, InlineKeyboardMarkup, int]: text and replyMarkup that make up the reply, new conversation state
     """
-    message_text = "Va bene, alla prossima 🙃"
-    return message_text, None, STATE['end']
+    if arg == "anonimo":  # if the user wants to be anonym
+        if MemeData.become_anonym(user_id=info['sender_id']):  # if the user was already anonym
+            text = "Sei già anonimo"
+        else:
+            text = "La tua preferenza è stata aggiornata\n"\
+                "Ora i tuoi post saranno anonimi"
 
+    elif arg == "credit":  # if the user wants to be credited
+        if MemeData.become_credited(user_id=info['sender_id']):
+            text = "Sei già creditato nei post\n"
+        else:
+            text = "La tua preferenza è stata aggiornata\n"
 
-def settings_anonimo_callback(info: dict) -> Tuple[str, InlineKeyboardMarkup, int]:
-    """Handles the settings_sei_ghei callback.
-    Removes the user_id from the table of credited users, if present
-
-    Args:
-        info (dict): information about the callback
-
-    Returns:
-        Tuple[str, InlineKeyboardMarkup, int]: text and replyMarkup that make up the reply, new conversation state
-    """
-    # if the user was already anonym
-    if MemeData.become_anonym(user_id=info['sender_id']):
-        text = "Sei già anonimo"
+        if info['sender_username']:  # the user has a valid username
+            text += f"I tuoi post avranno come credit @{info['sender_username']}"
+        else:
+            text += "ATTENZIONE:\nNon hai nessun username associato al tuo account telegram\n"\
+                "Se non lo aggiungi, non sarai creditato"
     else:
-        text = "La tua preferenza è stata aggiornata\n"\
-            "Ora i tuoi post saranno anonimi"
+        text = None
+        logger.error("settings_callback: invalid arg '%s'", arg)
 
     return text, None, None
 
 
-def settings_credit_callback(info: dict) -> Tuple[str, InlineKeyboardMarkup, int]:
-    """Handles the settings_foto_cane callback.
-    Adds the user_id to the table of credited users, if it wasn't already there
-
-    Args:
-        info (dict): information about the callback
-
-    Returns:
-        Tuple[str, InlineKeyboardMarkup, int]: text and replyMarkup that make up the reply, new conversation state
-    """
-    # if the user was already credited
-    if MemeData.become_credited(user_id=info['sender_id']):
-        text = "Sei già creditato nei post\n"
-    else:
-        text = "La tua preferenza è stata aggiornata\n"
-
-    if info['sender_username']:  # the user has a valid username
-        text += f"I tuoi post avranno come credit @{info['sender_username']}"
-    else:
-        text += "ATTENZIONE:\nNon hai nessun username associato al tuo account telegram\n"\
-            "Se non lo aggiungi, non sarai creditato"
-    return text, None, None
-
-
-def approve_yes_callback(info: dict) -> Tuple[str, InlineKeyboardMarkup, int]:
+def approve_yes_callback(info: dict, arg: None) -> Tuple[str, InlineKeyboardMarkup, int]:  # pylint: disable=unused-argument
     """Handles the approve_yes callback.
     Approves the post, deleting it from the pending_post table, publishing it in the channel \
     and putting it in the published post table
@@ -162,7 +155,7 @@ def approve_yes_callback(info: dict) -> Tuple[str, InlineKeyboardMarkup, int]:
     return None, None, None
 
 
-def approve_no_callback(info: dict) -> Tuple[str, InlineKeyboardMarkup, int]:
+def approve_no_callback(info: dict, arg: None) -> Tuple[str, InlineKeyboardMarkup, int]:  # pylint: disable=unused-argument
     """Handles the approve_no callback.
     Rejects the post, deleting it from the pending_post table
 
@@ -197,56 +190,29 @@ def approve_no_callback(info: dict) -> Tuple[str, InlineKeyboardMarkup, int]:
     return None, None, None
 
 
-def vote_yes_callback(info: dict) -> Tuple[str, InlineKeyboardMarkup, int]:
-    """Handles the vote_yes callback.
-    Upvotes the post
+def vote_callback(info: dict, arg: str) -> Tuple[str, InlineKeyboardMarkup, int]:
+    """Handles the vote,[ 0 | 1 | 2 | 3 | 4 ] callback.
 
     Args:
         info (dict): information about the callback
+        arg (str): [ 0 | 1 | 2 | 3 | 4 ]
+
 
     Returns:
         Tuple[str, InlineKeyboardMarkup, int]: text and replyMarkup that make up the reply, new conversation state
     """
-    n_upvotes, was_added = MemeData.set_user_vote(user_id=info['sender_id'],
-                                                  c_message_id=info['message_id'],
-                                                  channel_id=info['chat_id'],
-                                                  vote=True)
+    was_added = MemeData.set_user_vote(user_id=info['sender_id'],
+                                       c_message_id=info['message_id'],
+                                       channel_id=info['chat_id'],
+                                       vote=arg)
 
-    if n_upvotes != -1:  # the vote changed
-        if was_added:
-            info['bot'].answerCallbackQuery(callback_query_id=info['query_id'], text="Hai messo un 👍")
-        else:
-            info['bot'].answerCallbackQuery(callback_query_id=info['query_id'], text="Hai tolto il 👍")
-        keyboard = info['reply_markup'].inline_keyboard
-        return None, update_vote_kb(keyboard, info['message_id'], info['chat_id'], upvote=n_upvotes), None
+    if was_added:
+        info['bot'].answerCallbackQuery(callback_query_id=info['query_id'], text=f"Hai messo un {REACTION[arg]}")
+    else:
+        info['bot'].answerCallbackQuery(callback_query_id=info['query_id'], text=f"Hai tolto il {REACTION[arg]}")
 
-    return None, None, None
-
-
-def vote_no_callback(info: dict) -> Tuple[str, InlineKeyboardMarkup, int]:
-    """Handles the vote_no callback.
-    Downvotes the post
-
-    Args:
-        info (dict): information about the callback
-
-    Returns:
-        Tuple[str, InlineKeyboardMarkup, int]: text and replyMarkup that make up the reply, new conversation state
-    """
-    n_downvotes, was_added = MemeData.set_user_vote(user_id=info['sender_id'],
-                                                    c_message_id=info['message_id'],
-                                                    channel_id=info['chat_id'],
-                                                    vote=False)
-
-    if n_downvotes != -1:  # the vote changed
-        if was_added:
-            info['bot'].answerCallbackQuery(callback_query_id=info['query_id'], text="Hai messo un 👎")
-        else:
-            info['bot'].answerCallbackQuery(callback_query_id=info['query_id'], text="Hai tolto il 👎")
-        keyboard = keyboard = info['reply_markup'].inline_keyboard
-        return None, update_vote_kb(keyboard, info['message_id'], info['chat_id'], downvote=n_downvotes), None
-
-    return None, None, None
+    keyboard = info['reply_markup'].inline_keyboard
+    return None, update_vote_kb(keyboard, info['message_id'], info['chat_id']), None
 
 
 # endregion
@@ -276,59 +242,55 @@ def stats_callback(update: Update, context: CallbackContext):
         info['bot'].edit_message_reply_markup(chat_id=info['chat_id'], message_id=info['message_id'], reply_markup=None)
 
 
+# region handle stats_callback
 def avg_callback(arg: str) -> str:
-    """Handles the avg_* callback.
+    """Handles the avg_[ votes | 0 | 1 ] callback.
     Shows the average of the %arg per post
 
     Args:
-        arg (str): [ votes | yes | no ]
+        arg (str): [ votes | 0 | 1 ]
 
     Returns:
         str: text for the reply
     """
-    if arg == "yes":
-        avg_votes = MemeData.get_avg(True)
-        text = f"Gli spot ricevono in media {avg_votes} 👍"
-    elif arg == "no":
-        avg_votes = MemeData.get_avg(False)
-        text = f"Gli spot ricevono in media {avg_votes} 👎"
-    else:
+    if arg == "votes":
         avg_votes = MemeData.get_avg()
         text = f"Gli spot ricevono in media {avg_votes} voti"
+    else:
+        avg_votes = MemeData.get_avg(arg)
+        text = f"Gli spot ricevono in media {avg_votes} {REACTION[arg]}"
 
     return text
 
 
 def max_callback(arg: str) -> str:
-    """Handles the max_* callback
+    """Handles the max_[ votes | 0 | 1 ] callback
     Shows the post with the most %arg
 
     Args:
-        arg (str): [ votes | yes | no ]
+        arg (str): [ votes | 0 | 1 ]
 
     Returns:
         str: text for the reply
     """
-    if arg == "yes":
-        max_votes, message_id, channel_id = MemeData.get_max_id(True)
-        text = f"Lo spot con più 👍 ne ha {max_votes} (hurray)\n" \
-                f"Lo trovi a questo link: https://t.me/c/{channel_id[4:]}/{message_id}"
-    elif arg == "no":
-        max_votes, message_id, channel_id = MemeData.get_max_id(False)
-        text = f"Lo spot con più 👎 ne ha {max_votes} (yikes)\n"\
-            f"Lo trovi a questo link: https://t.me/c/{channel_id[4:]}/{message_id}"
-    else:
+    if arg == "votes":
         max_votes, message_id, channel_id = MemeData.get_max_id()
         text = f"Lo spot con più voti ne ha {max_votes}\n"\
+                f"Lo trovi a questo link: https://t.me/c/{channel_id[4:]}/{message_id}"
+    else:
+        max_votes, message_id, channel_id = MemeData.get_max_id(arg)
+        text = f"Lo spot con più {REACTION[arg]} ne ha {max_votes}\n" \
                 f"Lo trovi a questo link: https://t.me/c/{channel_id[4:]}/{message_id}"
 
     return text
 
+
 def tot_callback(arg: str) -> str:
-    """Handles the tot_* callback
+    """Handles the tot_[ posts | votes | 0 | 1 ] callback
     Shows the total number of %arg
+
     Args:
-        arg (str): [ posts | votes | yes | no ]
+        arg (str): [ posts | votes | 0 | 1 ]
 
     Returns:
         str: text for the reply
@@ -336,19 +298,17 @@ def tot_callback(arg: str) -> str:
     if arg == "posts":
         n_posts = MemeData.get_n_posts()
         text = f"Sono stati pubblicati {n_posts} spot nel canale fin'ora.\nPotresti ampliare questo numero..."
-    elif arg == "yes":
-        n_votes = MemeData.get_n_votes(True)
-        text = f"Il totale dei 👍 ammonta a {n_votes}"
-    elif arg == "no":
-        n_votes = MemeData.get_n_votes(False)
-        text = f"Il totale dei 👎 ammonta a {n_votes}"
-    else:
+    elif arg == "votes":
         n_votes = MemeData.get_n_votes()
         text = f"Il totale dei voti ammonta a {n_votes}"
+    else:
+        n_votes = MemeData.get_n_votes(arg)
+        text = f"Il totale dei {REACTION[arg]} ammonta a {n_votes}"
 
     return text
 
-def close_callback(arg) -> str: # pylint: disable=unused-argument
+
+def close_callback(arg: None) -> str:  # pylint: disable=unused-argument
     """Handles the close callback
     Closes the stats menu
 
@@ -356,3 +316,6 @@ def close_callback(arg) -> str: # pylint: disable=unused-argument
         str: text and replyMarkup that make up the reply
     """
     return None
+
+
+# endregion

--- a/modules/handlers/callback_handlers.py
+++ b/modules/handlers/callback_handlers.py
@@ -3,15 +3,13 @@ from typing import Tuple
 from telegram import Update, InlineKeyboardMarkup
 from telegram.ext import CallbackContext
 from telegram.error import BadRequest, Unauthorized
+from modules.handlers import STATE
 from modules.debug.log_manager import logger
 from modules.data.data_reader import config_map
 from modules.data.meme_data import MemeData
 from modules.utils.info_util import get_callback_info
 from modules.utils.keyboard_util import REACTION, update_approve_kb, update_vote_kb, get_stats_kb
 from modules.utils.post_util import send_post_to, show_admins_votes
-
-STATE = {'posting': 1, 'confirm': 2, 'end': -1}
-REACTION = {'0': "👎", '1': "👍", '2': "🤣", '3': "😡", '4': "🥰"}
 
 
 def old_reactions(data: str) -> str:
@@ -334,3 +332,6 @@ def close_callback(arg: None) -> str:  # pylint: disable=unused-argument
         str: text and replyMarkup that make up the reply
     """
     return None
+
+
+# endregion

--- a/modules/handlers/command_handlers.py
+++ b/modules/handlers/command_handlers.py
@@ -2,6 +2,7 @@
 from telegram import Update, ParseMode
 from telegram.ext import CallbackContext
 from telegram.error import BadRequest, Unauthorized
+from modules.handlers import STATE
 from modules.handlers.job_handlers import clean_pending_job
 from modules.debug.log_manager import logger
 from modules.data.data_reader import read_md, config_map
@@ -9,9 +10,6 @@ from modules.data.meme_data import MemeData
 from modules.utils.info_util import get_message_info, check_message_type
 from modules.utils.post_util import send_post_to
 from modules.utils.keyboard_util import get_confirm_kb, get_settings_kb, get_stats_kb
-
-STATE = {'posting': 1, 'confirm': 2, 'end': -1}
-
 
 # region cmd
 def start_cmd(update: Update, context: CallbackContext):

--- a/modules/handlers/command_handlers.py
+++ b/modules/handlers/command_handlers.py
@@ -1,5 +1,5 @@
 """Handles the execution of commands by the bot"""
-from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, ParseMode
+from telegram import Update, ParseMode
 from telegram.ext import CallbackContext
 from telegram.error import BadRequest, Unauthorized
 from modules.handlers.job_handlers import clean_pending_job
@@ -8,7 +8,7 @@ from modules.data.data_reader import read_md, config_map
 from modules.data.meme_data import MemeData
 from modules.utils.info_util import get_message_info, check_message_type
 from modules.utils.post_util import send_post_to
-from modules.utils.keyboard_util import get_confirm_kb, get_stats_kb
+from modules.utils.keyboard_util import get_confirm_kb, get_settings_kb, get_stats_kb
 
 STATE = {'posting': 1, 'confirm': 2, 'end': -1}
 
@@ -81,14 +81,9 @@ def settings_cmd(update: Update, context: CallbackContext):
         )
         return
 
-    keyboard = [[
-        InlineKeyboardButton(" Anonimo ", callback_data="meme_settings_anonimo"),
-        InlineKeyboardButton(" Con credit ", callback_data="meme_settings_credit"),
-    ]]
-
     info['bot'].send_message(chat_id=info['chat_id'],
                              text="***Come vuoi che sia il tuo post:***",
-                             reply_markup=InlineKeyboardMarkup(keyboard),
+                             reply_markup=get_settings_kb(),
                              parse_mode=ParseMode.MARKDOWN_V2)
 
 

--- a/modules/handlers/command_handlers.py
+++ b/modules/handlers/command_handlers.py
@@ -283,6 +283,8 @@ def forwarded_post_msg(update: Update, context: CallbackContext):
         context (CallbackContext): context passed by the handler
     """
     info = get_message_info(update, context)
+    if update.message.forward_from_chat is None:
+        return
     forward_from_chat_id = update.message.forward_from_chat.id
     forward_from_id = update.message.forward_from_message_id
 

--- a/modules/handlers/command_handlers.py
+++ b/modules/handlers/command_handlers.py
@@ -220,7 +220,9 @@ def cancel_cmd(update: Update, context: CallbackContext) -> int:
         int: next state of the conversation
     """
     info = get_message_info(update, context)
-
+    g_message_id, group_id = MemeData.cancel_pending_meme(user_id=info['sender_id'])
+    if g_message_id is not None:
+        info['bot'].delete_message(chat_id=group_id, message_id=g_message_id)
     info['bot'].send_message(chat_id=info['chat_id'], text="Post annullato")
     return STATE['end']
 

--- a/modules/utils/__init__.py
+++ b/modules/utils/__init__.py
@@ -1,1 +1,3 @@
 """Modules that provide various util"""
+
+REACTION = {'0': "👎", '1': "👍", '2': "🤣", '3': "😡", '4': "🥰"}

--- a/modules/utils/keyboard_util.py
+++ b/modules/utils/keyboard_util.py
@@ -3,8 +3,7 @@ Callback_data format: <callback_family>_<callback_name>,[arg]"""
 from typing import List
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from modules.data.meme_data import MemeData
-
-REACTION = {'0': "👎", '1': "👍", '2': "🤣", '3': "😡", '4': "🥰"}
+from modules.utils import REACTION
 
 
 def get_confirm_kb() -> InlineKeyboardMarkup:
@@ -129,10 +128,10 @@ def update_vote_kb(keyboard: List[List[InlineKeyboardButton]], c_message_id: int
     Returns:
         InlineKeyboardMarkup: updated inline keyboard
     """
-    keyboard[0][0].text = f"👍 {MemeData.get_published_votes(c_message_id, channel_id, vote='1')}"
-    keyboard[0][1].text = f"👎 {MemeData.get_published_votes(c_message_id, channel_id, vote='0')}"
+    keyboard[0][0].text = f"{REACTION['1']} {MemeData.get_published_votes(c_message_id, channel_id, vote='1')}"
+    keyboard[0][1].text = f"{REACTION['0']} {MemeData.get_published_votes(c_message_id, channel_id, vote='0')}"
     if len(keyboard) > 1:  # to keep support for older published memes
-        keyboard[1][0].text = f"🤣 {MemeData.get_published_votes(c_message_id, channel_id, vote='2')}"
-        keyboard[1][1].text = f"😡 {MemeData.get_published_votes(c_message_id, channel_id, vote='3')}"
-        keyboard[1][2].text = f"🥰 {MemeData.get_published_votes(c_message_id, channel_id, vote='4')}"
+        keyboard[1][0].text = f"{REACTION['2']} {MemeData.get_published_votes(c_message_id, channel_id, vote='2')}"
+        keyboard[1][1].text = f"{REACTION['3']} {MemeData.get_published_votes(c_message_id, channel_id, vote='3')}"
+        keyboard[1][2].text = f"{REACTION['4']} {MemeData.get_published_votes(c_message_id, channel_id, vote='4')}"
     return InlineKeyboardMarkup(keyboard)

--- a/modules/utils/keyboard_util.py
+++ b/modules/utils/keyboard_util.py
@@ -1,7 +1,9 @@
-"""Creates the inlinekeyboard sent by the bot in its messages"""
+"""Creates the inlinekeyboard sent by the bot in its messages.
+Callback_data format: <callback_family>_<callback_name>,[arg]"""
 from typing import List
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from modules.data.meme_data import MemeData
+
 
 
 def get_confirm_kb() -> InlineKeyboardMarkup:
@@ -11,8 +13,20 @@ def get_confirm_kb() -> InlineKeyboardMarkup:
         InlineKeyboardMarkup: new inline keyboard
     """
     return InlineKeyboardMarkup([[
-        InlineKeyboardButton(text="Si", callback_data="meme_confirm_yes"),
-        InlineKeyboardButton(text="No", callback_data="meme_confirm_no")
+        InlineKeyboardButton(text="Si", callback_data="meme_confirm,yes"),
+        InlineKeyboardButton(text="No", callback_data="meme_confirm,no")
+    ]])
+
+
+def get_settings_kb() -> InlineKeyboardMarkup:
+    """Generates the InlineKeyboard to edit the settings
+
+    Returns:
+        InlineKeyboardMarkup: new inline keyboard
+    """
+    return InlineKeyboardMarkup([[
+        InlineKeyboardButton(" Anonimo ", callback_data="meme_settings,anonimo"),
+        InlineKeyboardButton(" Con credit ", callback_data="meme_settings,credit"),
     ]])
 
 
@@ -53,8 +67,8 @@ def get_approve_kb() -> InlineKeyboardMarkup:
         InlineKeyboardMarkup: new inline keyboard
     """
     return InlineKeyboardMarkup([[
-        InlineKeyboardButton("🟢 0", callback_data="meme_approve_yes"),
-        InlineKeyboardButton("🔴 0", callback_data="meme_approve_no")
+        InlineKeyboardButton("🟢 0", callback_data="meme_approve_yes,"),
+        InlineKeyboardButton("🔴 0", callback_data="meme_approve_no,")
     ]])
 
 
@@ -65,8 +79,8 @@ def get_vote_kb() -> InlineKeyboardMarkup:
         InlineKeyboardMarkup: new inline keyboard
     """
     return InlineKeyboardMarkup([[
-        InlineKeyboardButton("👍 0", callback_data="meme_vote_yes"),
-        InlineKeyboardButton("👎 0", callback_data="meme_vote_no")
+        InlineKeyboardButton("👍 0", callback_data="meme_vote,1"),
+        InlineKeyboardButton("👎 0", callback_data="meme_vote,0")
     ]])
 
 

--- a/modules/utils/keyboard_util.py
+++ b/modules/utils/keyboard_util.py
@@ -5,7 +5,6 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from modules.data.meme_data import MemeData
 
 
-
 def get_confirm_kb() -> InlineKeyboardMarkup:
     """Generates the InlineKeyboard to confirm the creation of the post
 
@@ -40,21 +39,21 @@ def get_stats_kb() -> InlineKeyboardMarkup:
         [InlineKeyboardButton("~  Lo spot con più ___  ~", callback_data="none")],
         [
             InlineKeyboardButton("voti", callback_data="stats_max,votes"),
-            InlineKeyboardButton("👍", callback_data="stats_max,yes"),
-            InlineKeyboardButton("👎", callback_data="stats_max,no"),
+            InlineKeyboardButton("👍", callback_data="stats_max,1"),
+            InlineKeyboardButton("👎", callback_data="stats_max,0"),
         ],
         [InlineKeyboardButton("~  Media di ___ per spot  ~", callback_data="none")],
         [
             InlineKeyboardButton("voti", callback_data="stats_avg,votes"),
-            InlineKeyboardButton("👍", callback_data="stats_avg,yes"),
-            InlineKeyboardButton("👎", callback_data="stats_avg,no"),
+            InlineKeyboardButton("👍", callback_data="stats_avg,1"),
+            InlineKeyboardButton("👎", callback_data="stats_avg,0"),
         ],
         [InlineKeyboardButton("~  Numero di ___ totale  ~", callback_data="none")],
         [
             InlineKeyboardButton("spot", callback_data="stats_tot,posts"),
             InlineKeyboardButton("voti", callback_data="stats_tot,votes"),
-            InlineKeyboardButton("👍", callback_data="stats_tot,yes"),
-            InlineKeyboardButton("👎", callback_data="stats_tot,no"),
+            InlineKeyboardButton("👍", callback_data="stats_tot,1"),
+            InlineKeyboardButton("👎", callback_data="stats_tot,0"),
         ],
         [InlineKeyboardButton("Chiudi", callback_data="stats_close,")],
     ])
@@ -78,10 +77,14 @@ def get_vote_kb() -> InlineKeyboardMarkup:
     Returns:
         InlineKeyboardMarkup: new inline keyboard
     """
-    return InlineKeyboardMarkup([[
-        InlineKeyboardButton("👍 0", callback_data="meme_vote,1"),
-        InlineKeyboardButton("👎 0", callback_data="meme_vote,0")
-    ]])
+    return InlineKeyboardMarkup(
+        [[InlineKeyboardButton("👍 0", callback_data="meme_vote,1"),
+          InlineKeyboardButton("👎 0", callback_data="meme_vote,0")],
+         [
+             InlineKeyboardButton("🤣 0", callback_data="meme_vote,2"),
+             InlineKeyboardButton("😡 0", callback_data="meme_vote,3"),
+             InlineKeyboardButton("🥰 0", callback_data="meme_vote,4"),
+         ]])
 
 
 def update_approve_kb(keyboard: List[List[InlineKeyboardButton]],
@@ -112,29 +115,21 @@ def update_approve_kb(keyboard: List[List[InlineKeyboardButton]],
     return InlineKeyboardMarkup(keyboard)
 
 
-def update_vote_kb(keyboard: List[List[InlineKeyboardButton]],
-                   c_message_id: int,
-                   channel_id: int,
-                   upvote: int = -1,
-                   downvote: int = -1) -> InlineKeyboardMarkup:
+def update_vote_kb(keyboard: List[List[InlineKeyboardButton]], c_message_id: int, channel_id: int) -> InlineKeyboardMarkup:
     """Updates the InlineKeyboard when the valutation of a published post changes
 
     Args:
         keyboard (List[List[InlineKeyboardButton]]): previous keyboard
         c_message_id (int): id of the published post in question
         channel_id (int): id of the channel
-        upvote (int, optional): number of upvotes, if known. Defaults to -1.
-        downvote (int, optional): number of downvotes, if known. Defaults to -1.
 
     Returns:
         InlineKeyboardMarkup: updated inline keyboard
     """
-    if upvote >= 0:
-        keyboard[0][0].text = f"👍 {upvote}"
-    else:
-        keyboard[0][0].text = f"👍 {MemeData.get_published_votes(c_message_id, channel_id, vote=True)}"
-    if downvote >= 0:
-        keyboard[0][1].text = f"👎 {downvote}"
-    else:
-        keyboard[0][1].text = f"👎 {MemeData.get_published_votes(c_message_id, channel_id, vote=False)}"
+    keyboard[0][0].text = f"👍 {MemeData.get_published_votes(c_message_id, channel_id, vote='1')}"
+    keyboard[0][1].text = f"👎 {MemeData.get_published_votes(c_message_id, channel_id, vote='0')}"
+    if len(keyboard) > 1:  # to keep support for older published memes
+        keyboard[1][0].text = f"🤣 {MemeData.get_published_votes(c_message_id, channel_id, vote='2')}"
+        keyboard[1][1].text = f"😡 {MemeData.get_published_votes(c_message_id, channel_id, vote='3')}"
+        keyboard[1][2].text = f"🥰 {MemeData.get_published_votes(c_message_id, channel_id, vote='4')}"
     return InlineKeyboardMarkup(keyboard)

--- a/modules/utils/post_util.py
+++ b/modules/utils/post_util.py
@@ -83,7 +83,6 @@ def send_post_to(message: Message, bot: Bot, destination: str, user_id: int = No
         logger.error("Sending the post on send_post_to: %s", e)
         return None
 
-
     if destination == "admin":  # insert the post among the pending ones
         MemeData.insert_pending_post(user_message=message, admin_message=post_message)
     elif destination == "channel":  # insert the post among the published ones and show the credtit...
@@ -140,9 +139,10 @@ def show_admins_votes(chat_id: int, message_id: int, bot: Bot, approve: bool):
     """
     admins = MemeData.get_list_admin_votes(g_message_id=message_id, group_id=chat_id, vote=approve)
     text = "Approvato da:\n" if approve else "Rifiutato da:\n"
+    tag = '@' if config_map['meme']['tag'] else ''
     for admin in admins:
         username = bot.get_chat(admin).username
-        text += f"@{username}\n" if username else f"{bot.get_chat(admin).first_name}\n"
+        text += f"{tag}{username}\n" if username else f"{bot.get_chat(admin).first_name}\n"
 
     bot.edit_message_reply_markup(chat_id=chat_id, message_id=message_id, reply_markup=None)
     bot.send_message(chat_id=chat_id, text=text, reply_to_message_id=message_id)


### PR DESCRIPTION
- The /cancel command now also allows the user to remove a post that is still pending, allowing him to spot immediately.
- The user tags used to show who, among the admins, approved or rejected a pending post, can be turned in inoffensive text (removing the @ at the beginning).
- Fixed a pesky bug that made the bot unresponsive to further /spots and forced the user to use the /cancel command.
- Some very minor refactoring.