### PR TITLE
Config changes and proof of concept of the /purge command

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -115,8 +115,6 @@ dmypy.json
 .pyre/
 
 # Config and data
-config/*.yaml
-data/yaml/reactions.yaml
 logs/*.log
 *.db
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN pip3 install -r requirements.txt
 
 COPY . .
 
-RUN if [ -f data/yaml/reactions.yaml.dist ]; then mv data/yaml/reactions.yaml.dist data/yaml/reactions.yaml; fi
+RUN if { [ -f config/settings.yaml.dist ] && [ ! -f config/settings.yaml ]; } then cp config/settings.yaml.dist config/settings.yaml; fi
+RUN if { [ -f data/yaml/reactions.yaml.dist ] && [ ! -f data/yaml/reactions.yaml ]; } then cp data/yaml/reactions.yaml.dist data/yaml/reactions.yaml; fi
 
 #Start the bot
 ENTRYPOINT [ "python3", "main.py" ]

--- a/README.md
+++ b/README.md
@@ -33,34 +33,35 @@ Listed in requirements.txt
 ### Steps:
 - Clone this repository
 - \[_OPTIONAL_\] Rename "data/yaml/reactions.yaml.dist" in "data/yaml/reactions.yaml" or simply create the latter and edit the desired parameters. 
--  Rename "config/settings.yaml.dist" in "config/settings.yaml" or simply create the latter and edit the desired parameters. **Make sure to add a valid _token_ setting**.
+-  Rename "config/settings.yaml.dist" in "config/settings.yaml" or simply create the latter and edit the desired parameters. **Make sure to add a valid _token_ setting**.  
+What follows are some example settings with explaination for each:
 ```yaml
 debug:
-  local_log: save each and every message in a log file. Make sure the path "logs/messages.log" is valid before putting it to 1
+  local_log: false        # save each and every message in a log file. Make sure the path "logs/messages.log" is valid when enabled
 
 meme:
-  channel_group_id: id of the group associated with the channel. Required if comments are enabled
-  channel_id: id of the channel to which the bot will send the approved memes
-  channel_tag: tag of the channel to which the bot will send the approved memes
-  comments: whether or not the channel the bot will send the memes to has comments enabled
-  group_id: id of the admin group the memebot will use
-  n_votes: votes needed to approve/reject a pending post
-  remove_after_h: number of hours after wich pending posts will be automatically by /clean_pending
-  reset_on_load: whether or not the database should reset every time the bot launches. USE CAREFULLY
-  report_wait_mins: number of minutes the user has to wait before being able to report another user again
-  tag: whether or not the bot should tag the admins or just write their usernames
+  channel_group_id: -100  # id of the group associated with the channel. Required if comments are enabled
+  channel_id: -200        # id of the channel to which the bot will send the approved memes
+  channel_tag: '@channel' # tag of the channel to which the bot will send the approved memes
+  comments: true          # whether or not the channel the bot will send the memes to has comments enabled
+  group_id: -300          # id of the admin group the memebot will use
+  n_votes: 2              # votes needed to approve/reject a pending post
+  remove_after_h: 12      # number of hours after wich pending posts will be automatically by /clean_pending
+  reset_on_load: false    # whether or not the database should reset every time the bot launches. USE CAREFULLY
+  report_wait_mins: 30    # number of minutes the user has to wait before being able to report another user again
+  tag: false              # whether or not the bot should tag the admins or just write their usernames
 
 test:
-  api_hash: hash of the telegram app used for testing
-  api_id: id of the telegram app used for testing
-  remote:  whether you want to test the remote database, the local one or both
-  session: session of the telegram app used for testing
-  bot_tag: tag of the telegram bot used for testing. Include the '@' character
-  token: token for the telegram bot used for testing
+  api_hash: XXXXXXXXXXX   # hash of the telegram app used for testing
+  api_id: 123456          # id of the telegram app used for testing
+  remote: false           # whether you want to test the remote database, the local one or both
+  session: XXXXXXXXXXXX   # session of the telegram app used for testing
+  bot_tag: '@test_bot'    # tag of the telegram bot used for testing. Include the '@' character
+  token: xxxxxxxxxxxx     # token for the telegram bot used for testing
   #... all the tags above. They will be overwritten when testing
 
-token: token of the telegram bot
-bot_tag: tag of the telegram bot
+token: xxxxxxxxxxxx       # token of the telegram bot
+bot_tag: '@bot'           # tag of the telegram bot
 ```
 - **Run** `python3 main.py`
 
@@ -72,16 +73,12 @@ bot_tag: tag of the telegram bot
 
 ### Steps:
 - Clone this repository
-- In "config/settings.yaml.dist", edit the desired values. Be mindful that the one listed below will overwrite the ones in "config/settings.yaml.dist", even if they aren't used in the command line
-- **Run** `docker build --tag botimage --build-arg TOKEN=<token_arg> <...> .` 
-
-| In the command line <br>(after each --build-arg) | Type | Function | Optional |
-| --- | --- | --- | --- |
-| **TOKEN=<token_args>** | string | the token for your telegram bot | REQUIRED |
-| **GROUP_ID=<group_id>** | int | id of the admin group the memebot will use | REQUIRED |
-| **CHANNEL_ID=<channel_id>** | int | id of the channel to which the bot will send the approved memes  | REQUIRED |
-| **CHANNEL_GROUP_ID=<channel_id>** | int | id of the group associated with the channel | REQUIRED IF<br>comments = true |
-- **Run** `docker run -d --name botcontainer botimage`
+- In _config/settings.yaml.dist_, edit the desired values. You can also rename it to _config/settings.yaml_ and edit the values there.
+- You can also leave the settings files alone, and instead use the environment variables on the container.  
+All the env vars with the same name (case insensitive) will override the ones in the settings file.
+To update the **meme** settings, prefix the env var name with **MEME_**. The same is true for the **test** settings, that have to be prefixed with **TEST_**.
+- **Run** `docker build --tag botimage .` 
+- **Run** `docker run -d --name botcontainer -e TOKEN=<token_arg> [other env vars] botimage`
 
 ### To stop/remove the container:
 - **Run** `docker stop botcontainer` to stop the container

--- a/data/markdown/instructions.md
+++ b/data/markdown/instructions.md
@@ -6,3 +6,4 @@
 \- per bannare un utente, rispondere al post che ha causato il ban con "/ban"
 \- per sbannare un utente, utilizzare il comando "/sban <id utente\>"
 \- utilizzare il comando "/clean\_pending" per rifiutare automaticamente tutti i post abbastanza vecchi
+\- utilizzare il comando "/purge" per eliminare dal database tutti i post e i rispettivi voti di cui si è perso il messaggio

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from modules.data import config_map
 # handlers
 from modules.handlers.command_handlers import STATE, start_cmd, help_cmd, settings_cmd, post_cmd, ban_cmd, reply_cmd,\
     clean_pending_cmd, post_msg, rules_cmd, sban_cmd, cancel_cmd, stats_cmd, forwarded_post_msg, report_post, report_cmd, \
-    report_user_msg, report_user_sent_msg
+    report_user_msg, report_user_sent_msg, purge_cmd
 from modules.handlers.callback_handlers import meme_callback, stats_callback
 from modules.handlers.job_handlers import clean_pending_job
 # endregion
@@ -89,6 +89,7 @@ def add_handlers(dp: Dispatcher):
     dp.add_handler(CommandHandler("settings", settings_cmd))
     dp.add_handler(CommandHandler("sban", sban_cmd))
     dp.add_handler(CommandHandler("clean_pending", clean_pending_cmd))
+    dp.add_handler(CommandHandler("purge", purge_cmd))
     dp.add_handler(CommandHandler("cancel", cancel_cmd))  # it must be after the conversation handler's 'cancel'
 
     # MessageHandler

--- a/modules/handlers/__init__.py
+++ b/modules/handlers/__init__.py
@@ -15,3 +15,5 @@ STATE = {
     'sending_user_report': 7,
     'end': -1
 }
+
+purge_flag = False

--- a/modules/handlers/command_handlers.py
+++ b/modules/handlers/command_handlers.py
@@ -235,7 +235,7 @@ def purge_cmd(update: Update, context: CallbackContext):
                 sleep(0.2)
         info.bot.send_message(
             info.chat_id,
-            text=f"Of the {total_posts} spots, {lost_posts} have not been found. The rateo is {round(lost_posts/total_posts, 3)}")
+            text=f"Dei {total_posts} totali, {lost_posts} sono andati persi. Il rapporto è {round(lost_posts/total_posts, 3)}")
 
 
 def cancel_cmd(update: Update, context: CallbackContext) -> int:


### PR DESCRIPTION
Minor config changes to allow the use of environment variables. These changes are applied to the Docker container too, so it's description has been updated.

Also, added the test for the /purge command, which, when fully enabled, should delete all the spots from the database for which the corresponding telegram message has been deleted.  
The issue is that, to check it, the message stored in the database is used to forward a dummy message in the admin group, promptly deleted. The process is easy, but for thousands of message can be slow and prone to flood errors, that should be prevented with some appropriate sleep between messages.   
Furthermore, since the bot is synchronous, until the command has finished, the bot won't accept any other command.

See if anyone has some better idea to achieve the same goal