### PR TITLE
fix: support for missing published posts in the db

### DIFF
--- a/modules/handlers/callback_handlers.py
+++ b/modules/handlers/callback_handlers.py
@@ -254,6 +254,10 @@ def vote_callback(info: EventInfo, arg: str) -> Tuple[str, InlineKeyboardMarkup,
         Tuple[str, InlineKeyboardMarkup, int]: text and replyMarkup that make up the reply, new conversation state
     """
     publishedPost = PublishedPost.from_channel(channel_id=info.chat_id, c_message_id=info.message_id)
+    if publishedPost is None:
+        publishedPost = PublishedPost.create(channel_id=info.chat_id, c_message_id=info.message_id)
+        publishedPost.set_votes(info.inline_keyboard)
+
     was_added = publishedPost.set_user_vote(user_id=info.user_id, vote=arg)
 
     if was_added:

--- a/modules/utils/info_util.py
+++ b/modules/utils/info_util.py
@@ -132,6 +132,13 @@ class EventInfo():
         return None
 
     @property
+    def inline_keyboard(self) -> InlineKeyboardMarkup:
+        """:class:`InlineKeyboardMarkup`: InlineKeyboard attached to the message. Defaults to None"""
+        if self.__message is None:
+            return None
+        return self.__message.reply_markup
+
+    @property
     def query_id(self) -> int:
         """:class:`int`: Id of the query that caused the update. Defaults to None"""
         if self.__query is None:


### PR DESCRIPTION
This "fix" allows the user to add a reaction to a published post that for some reason is no longer in the database.
The missing post will be added, along with a number of reactions according to the reply-keyboard associated with its telegram message.
The downside of this approach is that the old votes can be considered anonymous, since all data regarding the user that added it has been lost.
So a user that had already added a reaction before the post was lost can add another and cannot remove the previous.