### PR TITLE
fix: /stats call that didn't update the text

### DIFF
--- a/modules/handlers/callback_handlers.py
+++ b/modules/handlers/callback_handlers.py
@@ -49,7 +49,8 @@ def meme_callback(update: Update, context: CallbackContext) -> int:
         logger.error("meme_callback: %s", e)
 
     try:
-        if message_text:  # if there is a valid text, edit the menu with the new text
+        # if there is a valid text, edit the menu with the new text
+        if message_text and message_text != info.text:
             info.bot.edit_message_text(chat_id=info.chat_id,
                                        message_id=info.message_id,
                                        text=message_text,
@@ -234,12 +235,6 @@ def vote_callback(info: EventInfo, arg: str) -> Tuple[str, InlineKeyboardMarkup,
     return None, get_vote_kb(published_post=publishedPost), None
 
 
-
-
 # endregion
-
-
-
-
 
 # endregion

--- a/modules/handlers/stats.py
+++ b/modules/handlers/stats.py
@@ -39,11 +39,13 @@ def stats_callback(update: Update, context: CallbackContext):
         logger.error("stats_callback: %s", e)
         return
 
-    if message_text:  # if there is a valid text, edit the menu with the new text
-        info.bot.edit_message_text(chat_id=info.chat_id,
-                                   message_id=info.message_id,
-                                   text=message_text,
-                                   reply_markup=get_stats_kb())
+    # if there is a valid text, edit the menu with the new text
+    if message_text:
+        if message_text != info.text:
+            info.bot.edit_message_text(chat_id=info.chat_id,
+                                    message_id=info.message_id,
+                                    text=message_text,
+                                    reply_markup=get_stats_kb())
     else:  # remove the reply markup
         info.edit_inline_keyboard()
 


### PR DESCRIPTION
The /stats' command buttons should not trigger an edit_message_text if the text didn't change