### PR TITLE
Replace anonymous comments in group [ close #66 ]

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ The main ones are:
     reset_on_load: false    # whether or not the database should reset every time the bot launches. USE CAREFULLY
     report_wait_mins: 30    # number of minutes the user has to wait before being able to report another user again
     tag: false              # whether or not the bot should tag the admins or just write their usernames
+     # whether the bot should replace any anonymous comment with a message by itself. 
+     # The bots must have delete permission in the group and comments must be enabled
+    replace_anonymous_comments: true
 
   test:
     api_hash: XXXXXXXXXXX   # hash of the telegram app used for testing

--- a/config/settings.yaml.dist
+++ b/config/settings.yaml.dist
@@ -11,6 +11,7 @@ meme:
   reset_on_load: false
   tag: false
   report_wait_mins: 30
+  replace_anonymous_comments: true
 test:
   api_hash: ''
   api_id: -1

--- a/config/settings.yaml.dist
+++ b/config/settings.yaml.dist
@@ -18,5 +18,6 @@ test:
   session: ''
   bot_tag: ''
   token: ''
+  replace_anonymous_comments: true
 token: ''
 bot_tag: ''

--- a/main.py
+++ b/main.py
@@ -12,9 +12,10 @@ from modules.data import config_map
 # debug
 from modules.debug import error_handler, log_message
 # handlers
-from modules.handlers import (ban_cmd, cancel_cmd, clean_pending_cmd, clean_pending_job, db_backup_cmd, db_backup_job, forwarded_post_msg, help_cmd,
-                              purge_cmd, reply_cmd, rules_cmd, sban_cmd, settings_cmd, spot_conv_handler, start_cmd,
-                              stats_callback, stats_cmd, report_user_conv_handler, report_spot_conv_handler)
+from modules.handlers import (anonymus_comment_msg, ban_cmd, cancel_cmd, clean_pending_cmd, clean_pending_job, db_backup_cmd,
+                              db_backup_job, forwarded_post_msg, help_cmd, purge_cmd, reply_cmd, report_spot_conv_handler,
+                              report_user_conv_handler, rules_cmd, sban_cmd, settings_cmd, spot_conv_handler, start_cmd,
+                              stats_callback, stats_cmd)
 from modules.handlers.callback_handlers import meme_callback
 
 # endregion
@@ -80,6 +81,8 @@ def add_handlers(dp: Dispatcher):
 
     if config_map['meme']['comments']:
         dp.add_handler(MessageHandler(Filters.forwarded, forwarded_post_msg))
+        if config_map['meme']['replace_anonymous_comments']:
+            dp.add_handler(MessageHandler(Filters.reply & Filters.sender_chat.channel, anonymus_comment_msg, run_async=True))
 
 
 def add_jobs(dp: Dispatcher):

--- a/main.py
+++ b/main.py
@@ -80,7 +80,8 @@ def add_handlers(dp: Dispatcher):
     dp.add_handler(CallbackQueryHandler(stats_callback, pattern=r"^stats_\.*"))
 
     if config_map['meme']['comments']:
-        dp.add_handler(MessageHandler(Filters.forwarded & Filters.chat_type.groups, forwarded_post_msg))
+        dp.add_handler(
+            MessageHandler(Filters.forwarded & Filters.chat_type.groups & Filters.is_automatic_forward, forwarded_post_msg))
         if config_map['meme']['replace_anonymous_comments']:
             dp.add_handler(
                 MessageHandler(Filters.reply & Filters.sender_chat.channel & Filters.chat_type.groups,

--- a/main.py
+++ b/main.py
@@ -80,9 +80,12 @@ def add_handlers(dp: Dispatcher):
     dp.add_handler(CallbackQueryHandler(stats_callback, pattern=r"^stats_\.*"))
 
     if config_map['meme']['comments']:
-        dp.add_handler(MessageHandler(Filters.forwarded, forwarded_post_msg))
+        dp.add_handler(MessageHandler(Filters.forwarded & Filters.chat_type.groups, forwarded_post_msg))
         if config_map['meme']['replace_anonymous_comments']:
-            dp.add_handler(MessageHandler(Filters.reply & Filters.sender_chat.channel, anonymous_comment_msg, run_async=True))
+            dp.add_handler(
+                MessageHandler(Filters.reply & Filters.sender_chat.channel & Filters.chat_type.groups,
+                               anonymous_comment_msg,
+                               run_async=True))
 
 
 def add_jobs(dp: Dispatcher):

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ from modules.data import config_map
 # debug
 from modules.debug import error_handler, log_message
 # handlers
-from modules.handlers import (anonymus_comment_msg, ban_cmd, cancel_cmd, clean_pending_cmd, clean_pending_job, db_backup_cmd,
+from modules.handlers import (anonymous_comment_msg, ban_cmd, cancel_cmd, clean_pending_cmd, clean_pending_job, db_backup_cmd,
                               db_backup_job, forwarded_post_msg, help_cmd, purge_cmd, reply_cmd, report_spot_conv_handler,
                               report_user_conv_handler, rules_cmd, sban_cmd, settings_cmd, spot_conv_handler, start_cmd,
                               stats_callback, stats_cmd)
@@ -82,7 +82,7 @@ def add_handlers(dp: Dispatcher):
     if config_map['meme']['comments']:
         dp.add_handler(MessageHandler(Filters.forwarded, forwarded_post_msg))
         if config_map['meme']['replace_anonymous_comments']:
-            dp.add_handler(MessageHandler(Filters.reply & Filters.sender_chat.channel, anonymus_comment_msg, run_async=True))
+            dp.add_handler(MessageHandler(Filters.reply & Filters.sender_chat.channel, anonymous_comment_msg, run_async=True))
 
 
 def add_jobs(dp: Dispatcher):

--- a/modules/handlers/__init__.py
+++ b/modules/handlers/__init__.py
@@ -1,4 +1,5 @@
 """Modules that handle the events the bot recognizes and reacts to"""
+from .anonym_comment import anonymus_comment_msg
 from .ban import ban_cmd
 from .cancel import cancel_cmd
 from .clean_pending import clean_pending_cmd

--- a/modules/handlers/__init__.py
+++ b/modules/handlers/__init__.py
@@ -1,5 +1,5 @@
 """Modules that handle the events the bot recognizes and reacts to"""
-from .anonym_comment import anonymus_comment_msg
+from .anonym_comment import anonymous_comment_msg
 from .ban import ban_cmd
 from .cancel import cancel_cmd
 from .clean_pending import clean_pending_cmd

--- a/modules/handlers/anonym_comment.py
+++ b/modules/handlers/anonym_comment.py
@@ -1,0 +1,20 @@
+"""Anonym Comment on a post in the comment group"""
+from telegram import Update
+from telegram.ext import CallbackContext
+from modules.data import config_map
+from modules.utils import EventInfo
+
+
+def anonymus_comment_msg(update: Update, context: CallbackContext):
+    """Handles a new anonym comment on a post in the comment group.
+    Deletes the original post and sends a message with the same text, to avoid any abuse.
+
+    Args:
+        update (Update): update event
+        context (CallbackContext): context passed by the handler
+    """
+    info = EventInfo.from_message(update, context)
+
+    if info.chat_id == config_map['meme']['channel_group_id'] and info.message.via_bot is None:
+        info.message.copy(chat_id=info.chat_id, reply_to_message_id=info.message.reply_to_message.message_id)
+        info.message.delete()

--- a/modules/handlers/anonym_comment.py
+++ b/modules/handlers/anonym_comment.py
@@ -5,7 +5,7 @@ from modules.data import config_map
 from modules.utils import EventInfo
 
 
-def anonymus_comment_msg(update: Update, context: CallbackContext):
+def anonymous_comment_msg(update: Update, context: CallbackContext):
     """Handles a new anonym comment on a post in the comment group.
     Deletes the original post and sends a message with the same text, to avoid any abuse.
 

--- a/modules/handlers/forwarded_post.py
+++ b/modules/handlers/forwarded_post.py
@@ -18,6 +18,5 @@ def forwarded_post_msg(update: Update, context: CallbackContext):
         return
 
     if info.chat_id == config_map['meme']['channel_group_id']\
-        and info.forward_from_chat_id == config_map['meme']['channel_id']\
-        and info.message.is_automatic_forward:
+        and info.forward_from_chat_id == config_map['meme']['channel_id']:
         info.send_post_to_channel_group()

--- a/modules/handlers/forwarded_post.py
+++ b/modules/handlers/forwarded_post.py
@@ -19,5 +19,5 @@ def forwarded_post_msg(update: Update, context: CallbackContext):
 
     if info.chat_id == config_map['meme']['channel_group_id']\
         and info.forward_from_chat_id == config_map['meme']['channel_id']\
-        and info.user_name == "Telegram":
+        and info.message.is_automatic_forward:
         info.send_post_to_channel_group()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 APScheduler==3.6.3
-astroid==2.4.2
+astroid==2.6.6
 atomicwrites==1.4.0
 attrs==20.2.0
 certifi==2020.6.20
@@ -21,15 +21,15 @@ pyasn1==0.4.8
 pycodestyle==2.6.0
 pycparser==2.20
 pyparsing==2.4.7
-python-telegram-bot==13.3
+python-telegram-bot==13.9
 pytz==2020.1
 PyYAML==5.4.1
 requests==2.25.1
 rsa==4.7.2
 six==1.15.0
 toml==0.10.1
-tornado==6.0.4
+tornado==6.1
 tzlocal==2.1
 urllib3==1.26.5
 wrapt==1.12.1
-yapf==0.30.0
+yapf==0.31.0

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -103,7 +103,7 @@ def report_spot_message(local_table: DbManager, admin_group: Chat, channel: Chat
 
 @pytest.fixture(scope="class")
 def channel() -> Chat:
-    """Called once per at the beginning of each function.
+    """Called once per at the beginning of each class.
     Returns the channel chat
 
     Returns:
@@ -115,7 +115,7 @@ def channel() -> Chat:
 
 @pytest.fixture(scope="class")
 def admin_group() -> Chat:
-    """Called once per at the beginning of each function.
+    """Called once per at the beginning of each class.
     Returns the admin group chat
 
     Returns:
@@ -127,7 +127,7 @@ def admin_group() -> Chat:
 
 @pytest.fixture(scope="class")
 def channel_group() -> Chat:
-    """Called once per at the beginning of each function.
+    """Called once per at the beginning of each class.
     Returns the chat of the public group with the comments
 
     Returns:
@@ -507,6 +507,7 @@ class TestBot:
 
             telegram.send_forward_message(forward_message=telegram.messages[-4],
                                           chat=channel_group,
+                                          is_automatic_forward=True,
                                           user=user.User(1, first_name="Telegram", is_bot=False))
             assert telegram.last_message.text.startswith("by: ")
             assert PublishedPost(channel_id=channel.id, c_message_id=telegram.last_message.message_id)

--- a/tests/util.py
+++ b/tests/util.py
@@ -196,6 +196,7 @@ class TelegramSimulator():
                              date: datetime = None,
                              reply_markup: InlineKeyboardMarkup = None,
                              reply_to_message: Union[Message, int] = None,
+                             is_automatic_forward: bool = False,
                              **kwargs) -> Message:
         """Sends a message to the bot on behalf of the user
 
@@ -207,6 +208,7 @@ class TelegramSimulator():
             date: date when the message was sent. Defaults to None.
             reply_markup: reply markup to use. Defaults to None.
             reply_to_message: message (or message_id of said message) to reply to. Defaults to None.
+            is_automatic_forward: whether the message was forwarded automatically by telegram. Defaults to False.
             **kwargs: additional parameters to be passed to the message. Defaults to None.
 
         Returns:
@@ -225,6 +227,7 @@ class TelegramSimulator():
                                         reply_markup=reply_markup,
                                         reply_to_message=reply_to_message,
                                         **kwargs)
+            message.is_automatic_forward = is_automatic_forward
         self.add_message(message)
         update = self.make_update(message)
         self.updater.dispatcher.process_update(update)


### PR DESCRIPTION
If the *replace_anonymous_comments* is enabled in the _settings.yaml_ file, the bot will check every reply in the comments group and replace any of those coming from a channel (anonymous user), by coping the message and deleting the original [ closes #66 ]