### PR TITLE
feat: added settings to disable bot reactions under spots

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The main ones are:
     remove_after_h: 12      # number of hours after wich pending posts will be automatically by /clean_pending
     reset_on_load: false    # whether or not the database should reset every time the bot launches. USE CAREFULLY
     report_wait_mins: 30    # number of minutes the user has to wait before being able to report another user again
+    report: true            # whether to add a report button as an inline keyboard after each post
     tag: false              # whether or not the bot should tag the admins or just write their usernames
      # whether the bot should replace any anonymous comment with a message by itself. 
      # The bots must have delete permission in the group and comments must be enabled

--- a/config/settings.yaml.default
+++ b/config/settings.yaml.default
@@ -10,6 +10,7 @@ meme:
   remove_after_h: 12
   reset_on_load: false
   tag: false
+  report: true
   report_wait_mins: 30
   replace_anonymous_comments: true
 test:
@@ -19,5 +20,7 @@ test:
   bot_tag: ''
   token: ''
   replace_anonymous_comments: true
+  comments: true
+  report: true
 token: ''
 bot_tag: ''

--- a/main.py
+++ b/main.py
@@ -82,11 +82,9 @@ def add_handlers(dp: Dispatcher):
     if config_map['meme']['comments']:
         dp.add_handler(
             MessageHandler(Filters.forwarded & Filters.chat_type.groups & Filters.is_automatic_forward, forwarded_post_msg))
-        if config_map['meme']['replace_anonymous_comments']:
-            dp.add_handler(
-                MessageHandler(Filters.sender_chat.channel & Filters.chat_type.groups,
-                               anonymous_comment_msg,
-                               run_async=True))
+    if config_map['meme']['replace_anonymous_comments']:
+        dp.add_handler(
+            MessageHandler(Filters.sender_chat.channel & Filters.chat_type.groups, anonymous_comment_msg, run_async=True))
 
 
 def add_jobs(dp: Dispatcher):

--- a/main.py
+++ b/main.py
@@ -84,7 +84,9 @@ def add_handlers(dp: Dispatcher):
             MessageHandler(Filters.forwarded & Filters.chat_type.groups & Filters.is_automatic_forward, forwarded_post_msg))
     if config_map['meme']['replace_anonymous_comments']:
         dp.add_handler(
-            MessageHandler(Filters.sender_chat.channel & Filters.chat_type.groups, anonymous_comment_msg, run_async=True))
+            MessageHandler(Filters.sender_chat.channel & Filters.chat_type.groups & ~Filters.is_automatic_forward,
+                           anonymous_comment_msg,
+                           run_async=True))
 
 
 def add_jobs(dp: Dispatcher):

--- a/modules/handlers/anonym_comment.py
+++ b/modules/handlers/anonym_comment.py
@@ -16,5 +16,6 @@ def anonymous_comment_msg(update: Update, context: CallbackContext):
     info = EventInfo.from_message(update, context)
 
     if info.chat_id == config_map['meme']['channel_group_id'] and info.message.via_bot is None:
-        info.message.copy(chat_id=info.chat_id, reply_to_message_id=info.message.reply_to_message.message_id if info.message.reply_to_message else None)
+        reply_to_message_id = info.message.reply_to_message.message_id if info.message.reply_to_message else None
+        info.message.copy(chat_id=info.chat_id, reply_to_message_id=reply_to_message_id)
         info.message.delete()

--- a/modules/handlers/report_spot.py
+++ b/modules/handlers/report_spot.py
@@ -39,7 +39,7 @@ def report_spot_callback(update: Update, context: CallbackContext) -> int:
         int: next state of the conversation
     """
     info = EventInfo.from_callback(update, context)
-    abusive_message_id = info.message.reply_to_message.message_id
+    abusive_message_id = info.message.reply_to_message.message_id if config_map['meme']['comments'] else info.message_id
 
     report = Report.get_post_report(user_id=info.user_id, channel_id=info.chat_id, c_message_id=abusive_message_id)
     if report is not None:  # this user has already reported this post

--- a/modules/utils/info_util.py
+++ b/modules/utils/info_util.py
@@ -271,7 +271,6 @@ class EventInfo():
     def send_post_to_channel(self, user_id: int):
         """Sends the post to  the channel, so it can be ejoyed by the users (and voted, if comments are disabled)
         """
-        user = User(user_id)
         message = self.__message
         channel_id = config_map['meme']['channel_id']
 
@@ -292,8 +291,6 @@ class EventInfo():
 
         if not config_map['meme']['comments']:  # if the user can vote directly on the post
             PublishedPost.create(c_message_id=c_message_id, channel_id=channel_id)
-            sign = user.get_user_sign(bot=self.__bot)
-            self.__bot.send_message(chat_id=channel_id, text=f"by: {sign}", reply_to_message_id=message.message_id)
         else:  # ... else, if comments are enabled, save the user_id, so the user can be credited
             self.bot_data[f"{channel_id},{c_message_id}"] = user_id
 

--- a/modules/utils/keyboard_util.py
+++ b/modules/utils/keyboard_util.py
@@ -95,12 +95,14 @@ def get_vote_kb(published_post: PublishedPost = None) -> InlineKeyboardMarkup:
             new_row.append(InlineKeyboardButton(f"{REACTION[reaction_id]} {n_votes}",
                                                 callback_data=f"meme_vote,{reaction_id}"))
         keyboard.append(new_row)
+
     # the last button in the last row will be the report button
+    report_button = InlineKeyboardButton("🚩 Report", callback_data="meme_report_spot,")
     if config_map['meme']['report']:
         if len(keyboard) > 0:
-            keyboard[-1].append(InlineKeyboardButton("🚩 Report", callback_data="meme_report_spot,"))
+            keyboard[-1].append(report_button)
         else:
-            keyboard.append([InlineKeyboardButton("🚩 Report", callback_data="meme_report_spot,")])
+            keyboard.append([report_button])
     return InlineKeyboardMarkup(keyboard)
 
 

--- a/modules/utils/keyboard_util.py
+++ b/modules/utils/keyboard_util.py
@@ -2,7 +2,7 @@
 Callback_data format: <callback_family>_<callback_name>,[arg]"""
 from typing import List
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
-from modules.data import PendingPost, PublishedPost, config_reactions
+from modules.data import PendingPost, PublishedPost, config_reactions, config_map
 
 REACTION = config_reactions['reactions']
 ROWS = config_reactions['rows']
@@ -96,7 +96,11 @@ def get_vote_kb(published_post: PublishedPost = None) -> InlineKeyboardMarkup:
                                                 callback_data=f"meme_vote,{reaction_id}"))
         keyboard.append(new_row)
     # the last button in the last row will be the report button
-    keyboard[-1].append(InlineKeyboardButton("🚩 Report", callback_data="meme_report_spot,"))
+    if config_map['meme']['report']:
+        if len(keyboard) > 0:
+            keyboard[-1].append(InlineKeyboardButton("🚩 Report", callback_data="meme_report_spot,"))
+        else:
+            keyboard.append([InlineKeyboardButton("🚩 Report", callback_data="meme_report_spot,")])
     return InlineKeyboardMarkup(keyboard)
 
 

--- a/modules/utils/keyboard_util.py
+++ b/modules/utils/keyboard_util.py
@@ -1,6 +1,6 @@
 """Creates the inlinekeyboard sent by the bot in its messages.
 Callback_data format: <callback_family>_<callback_name>,[arg]"""
-from typing import List
+from typing import List, Optional
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from modules.data import PendingPost, PublishedPost, config_reactions, config_map
 
@@ -78,14 +78,14 @@ def get_approve_kb() -> InlineKeyboardMarkup:
     ], [InlineKeyboardButton("⏹ Stop", callback_data="meme_approve_status,pause")]])
 
 
-def get_vote_kb(published_post: PublishedPost = None) -> InlineKeyboardMarkup:
+def get_vote_kb(published_post: PublishedPost = None) -> Optional[InlineKeyboardMarkup]:
     """Generates the InlineKeyboard for the published post and updates the correct number of reactions
 
     Args:
         published_post (PublishedPost, optional): published post to which the keyboard is attached. Defaults to None
 
     Returns:
-        InlineKeyboardMarkup: new inline keyboard
+        Optional[InlineKeyboardMarkup]: new inline keyboard
     """
     keyboard = []
     for row in ROWS:  # for each ROW or the keyboard...
@@ -97,13 +97,14 @@ def get_vote_kb(published_post: PublishedPost = None) -> InlineKeyboardMarkup:
         keyboard.append(new_row)
 
     # the last button in the last row will be the report button
-    report_button = InlineKeyboardButton("🚩 Report", callback_data="meme_report_spot,")
+    report_button = InlineKeyboardButton("🚩 Report", callback_data="meme_report_spot")
     if config_map['meme']['report']:
         if len(keyboard) > 0:
             keyboard[-1].append(report_button)
         else:
             keyboard.append([report_button])
-    return InlineKeyboardMarkup(keyboard)
+
+    return InlineKeyboardMarkup(keyboard) if keyboard else None
 
 
 def update_approve_kb(keyboard: List[List[InlineKeyboardButton]],


### PR DESCRIPTION
Added the ability to hide completely the inline keyboard of the spotted bot under the spots.
The settings mentioned below can be found in _config/settings.yaml_ (_report_, _comments_) and _data/yaml/reactions.yaml_ (_reactions_).

There following main combination of settings can be used to achieve different results:
- report: **true** | comments: **true** | reactionns; [ 0, 1, ..., n]: **current settings**
- report: **true** | comments: **true** | reactionns; []: same as now, but only the report button is visible
- report: **false** | comments: **true** | reactionns; []: the bot will still send a message in the comment channel, but without any inline keyboard
- report: **true** | comments: **false** | reactionns; [ 0, 1, ..., n]: the reactions are moved to the main channel. Comments are more difficult to access for users
- report: **true** | comments: **false** | reactionns; [ ]: the only the report button is moved to the main channel. Comments are more difficult to access for users
-  report: **false**| comments: **false** | reactionns; [ ]: the bot does nothing after publishing the spot

All of this is meant to make it easy to switch to the default telegram's reactions.