### PR TITLE
fix: add delete_anonymous_comments setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,14 @@ The main ones are:
     report_wait_mins: 30    # number of minutes the user has to wait before being able to report another user again
     report: true            # whether to add a report button as an inline keyboard after each post
     tag: false              # whether or not the bot should tag the admins or just write their usernames
-     # whether the bot should replace any anonymous comment with a message by itself. 
+     # whether the bot should delete any anonym comment coming from a channel.
      # The bots must have delete permission in the group and comments must be enabled
-    replace_anonymous_comments: true
+    delete_anonymous_comments: true
+     # whether the bot should replace any anonymous comment with a message by itself.
+     # WARNING: delete_anonymous_comments must be true for this option to make sense.
+     # Otherwise the comment would be doubled.
+     # The bots must have delete permission in the group and comments must be enabled
+    replace_anonymous_comments: false
 
   test:
     api_hash: XXXXXXXXXXX   # hash of the telegram app used for testing

--- a/config/settings.yaml.default
+++ b/config/settings.yaml.default
@@ -12,7 +12,8 @@ meme:
   tag: false
   report: true
   report_wait_mins: 30
-  replace_anonymous_comments: true
+  replace_anonymous_comments: false
+  delete_anonymous_comments: true
 test:
   api_hash: ''
   api_id: -1
@@ -20,6 +21,7 @@ test:
   bot_tag: ''
   token: ''
   replace_anonymous_comments: true
+  delete_anonymous_comments: true
   comments: true
   report: true
 token: ''

--- a/main.py
+++ b/main.py
@@ -82,7 +82,7 @@ def add_handlers(dp: Dispatcher):
     if config_map['meme']['comments']:
         dp.add_handler(
             MessageHandler(Filters.forwarded & Filters.chat_type.groups & Filters.is_automatic_forward, forwarded_post_msg))
-    if config_map['meme']['replace_anonymous_comments']:
+    if config_map['meme']['delete_anonymous_comments']:
         dp.add_handler(
             MessageHandler(Filters.sender_chat.channel & Filters.chat_type.groups & ~Filters.is_automatic_forward,
                            anonymous_comment_msg,

--- a/modules/handlers/anonym_comment.py
+++ b/modules/handlers/anonym_comment.py
@@ -16,6 +16,7 @@ def anonymous_comment_msg(update: Update, context: CallbackContext):
     info = EventInfo.from_message(update, context)
 
     if info.chat_id == config_map['meme']['channel_group_id'] and info.message.via_bot is None:
-        reply_to_message_id = info.message.reply_to_message.message_id if info.message.reply_to_message else None
-        info.message.copy(chat_id=info.chat_id, reply_to_message_id=reply_to_message_id)
+        if config_map['meme']['replace_anonymous_comments']:
+            reply_to_message_id = info.message.reply_to_message.message_id if info.message.reply_to_message else None
+            info.message.copy(chat_id=info.chat_id, reply_to_message_id=reply_to_message_id)
         info.message.delete()


### PR DESCRIPTION
Added delete_anonymous_comments, separated from the replace_anonymous_comments. 
This way, the bot can both delete the anonym comment and replace it, or simply delete it, based on the settings.