### PR TITLE
bump: python-telegram-bot to 21.0.1

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix **spam_comment_msg** handler to avoid raising an exception when the message does not contain text
 
-...
+### Changed
+
+- Bump python-telegram-bot to version 21.0.1
 
 ## [3.1.0] - 2024-02-18
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 dependencies = [
     "APScheduler==3.10.4",
     "cryptography==42.0.4",
-    "python-telegram-bot==20.8",
+    "python-telegram-bot==21.0.1",
     "pytz==2023.3.post1",
     "PyYAML==6.0.1",
 ]


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide](https://github.com/TendTo/dasaturn/blob/main/.github/CONTRIBUTING.rst).
- [x] The commit message follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines.
- [x] Tested the changes locally with a real Telegram bot.
- [x] I have updated the `CHANGELOG.rst` file with an overview of the changes made.

### Description

bump: python-telegram-bot to version 21.0.1

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

### Python version you are using

3.11.8
