### PR TITLE
fix: ensure message in report has a text

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix **spam_comment_msg** handler to avoid raising an exception when the message does not contain text
+- Ensure message in report has a text
 
 ### Changed
 

--- a/src/spotted/handlers/__init__.py
+++ b/src/spotted/handlers/__init__.py
@@ -141,7 +141,7 @@ def add_handlers(app: Application):
     if Config.post_get("blacklist_messages") and len(Config.post_get("blacklist_messages")) > 0:
         app.add_handler(
             MessageHandler(
-                community_filter & filters.Text(),
+                community_filter & filters.TEXT,
                 spam_comment_msg,
             ),
             2,

--- a/src/spotted/handlers/report_spot.py
+++ b/src/spotted/handlers/report_spot.py
@@ -30,7 +30,7 @@ def report_spot_conv_handler() -> ConversationHandler:
         entry_points=[CallbackQueryHandler(report_spot_callback, pattern=r"^report\.*")],
         states={
             ConversationState.REPORTING_SPOT.value: [
-                MessageHandler(~filters.COMMAND & ~filters.UpdateType.EDITED_MESSAGE, report_spot_msg)
+                MessageHandler(~filters.COMMAND & ~filters.UpdateType.EDITED_MESSAGE & filters.TEXT, report_spot_msg)
             ],
         },
         fallbacks=[CommandHandler("cancel", conv_cancel("report"))],


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide](https://github.com/TendTo/dasaturn/blob/main/.github/CONTRIBUTING.rst).
- [x] The commit message follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines.
- [x] Tested the changes locally with a real Telegram bot.
- [x] I have updated the `CHANGELOG.rst` file with an overview of the changes made.

### Description

Fix a bug where spamming non text message could allow for a report spam

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

### Python version you are using

3.11.8
